### PR TITLE
adding registry manipulation via StdRegProv

### DIFF
--- a/nursery/create-registry-key-via-stdregprov.yml
+++ b/nursery/create-registry-key-via-stdregprov.yml
@@ -1,0 +1,12 @@
+# generated using capa explorer for IDA Pro
+rule:
+  meta:
+    name: create registry key via StdRegProv
+    namespace: host-interaction/registry
+    author: michael.hunhoff@mandiant.com
+    scope: function
+    references: https://docs.microsoft.com/en-us/previous-versions/windows/desktop/regprov/stdregprov#methods
+  features:
+    - and:
+      - string: "StdRegProv"
+      - string: "CreateKey"

--- a/nursery/delete-registry-key-via-stdregprov.yml
+++ b/nursery/delete-registry-key-via-stdregprov.yml
@@ -1,0 +1,12 @@
+# generated using capa explorer for IDA Pro
+rule:
+  meta:
+    name: delete registry key via StdRegProv
+    namespace: host-interaction/registry
+    author: michael.hunhoff@mandiant.com
+    scope: function
+    references: https://docs.microsoft.com/en-us/previous-versions/windows/desktop/regprov/stdregprov#methods
+  features:
+    - and:
+      - string: "StdRegProv"
+      - string: "DeleteKey"

--- a/nursery/delete-registry-value-via-stdregprov.yml
+++ b/nursery/delete-registry-value-via-stdregprov.yml
@@ -1,0 +1,12 @@
+# generated using capa explorer for IDA Pro
+rule:
+  meta:
+    name: delete registry value via StdRegProv
+    namespace: host-interaction/registry
+    author: michael.hunhoff@mandiant.com
+    scope: function
+    references: https://docs.microsoft.com/en-us/previous-versions/windows/desktop/regprov/stdregprov#methods
+  features:
+    - and:
+      - string: "StdRegProv"
+      - string: "DeleteValue"

--- a/nursery/query-or-enumerate-registry-key-via-stdregprov.yml
+++ b/nursery/query-or-enumerate-registry-key-via-stdregprov.yml
@@ -9,5 +9,4 @@ rule:
   features:
     - and:
       - string: "StdRegProv"
-      - or:
-        - string: "EnumKey"
+      - string: "EnumKey"

--- a/nursery/query-or-enumerate-registry-key-via-stdregprov.yml
+++ b/nursery/query-or-enumerate-registry-key-via-stdregprov.yml
@@ -1,0 +1,13 @@
+# generated using capa explorer for IDA Pro
+rule:
+  meta:
+    name: query or enumerate registry key via StdRegProv
+    namespace: host-interaction/registry
+    author: michael.hunhoff@mandiant.com
+    scope: function
+    references: https://docs.microsoft.com/en-us/previous-versions/windows/desktop/regprov/stdregprov#methods
+  features:
+    - and:
+      - string: "StdRegProv"
+      - or:
+        - string: "EnumKey"

--- a/nursery/query-or-enumerate-registry-value-via-stdregprov.yml
+++ b/nursery/query-or-enumerate-registry-value-via-stdregprov.yml
@@ -1,0 +1,19 @@
+# generated using capa explorer for IDA Pro
+rule:
+  meta:
+    name: query or enumerate registry value via StdRegProv
+    namespace: host-interaction/registry
+    author: michael.hunhoff@mandiant.com
+    scope: function
+    references: https://docs.microsoft.com/en-us/previous-versions/windows/desktop/regprov/stdregprov#methods
+  features:
+    - and:
+      - string: "StdRegProv"
+      - or:
+        - string: "EnumValues"
+        - string: "GetBinaryValue"
+        - string: "GetDWORDValue"
+        - string: "GetExpandedStringValue"
+        - string: "GetMultiStringValue"
+        - string: "GetQWORDValue"
+        - string: "GetStringValue"

--- a/nursery/set-registry-value-via-stdregprov.yml
+++ b/nursery/set-registry-value-via-stdregprov.yml
@@ -1,0 +1,18 @@
+# generated using capa explorer for IDA Pro
+rule:
+  meta:
+    name: set registry value via StdRegProv
+    namespace: host-interaction/registry
+    author: michael.hunhoff@mandiant.com
+    scope: function
+    references: https://docs.microsoft.com/en-us/previous-versions/windows/desktop/regprov/stdregprov#methods
+  features:
+    - and:
+      - string: "StdRegProv"
+      - or:
+        - string: "SetBinaryValue"
+        - string: "SetDWORDValue"
+        - string: "SetExpandedStringValue"
+        - string: "SetMultiStringValue"
+        - string: "SetQWORDValue"
+        - string: "SetStringValue"


### PR DESCRIPTION
see #470 for more information. essentially, we hit on the strings passed to `GetObject`, e.g. `StdRegProv`, and `GetMethod`, e.g. `CreateKey`.