### PR TITLE
Add linked-against-wolfssl.yml and linked-against-wolfcrypt.yml

### DIFF
--- a/linking/static/wolfcrypt/linked-against-wolfcrypt.yml
+++ b/linking/static/wolfcrypt/linked-against-wolfcrypt.yml
@@ -1,0 +1,21 @@
+rule:
+  meta:
+    name: linked against wolfCrypt
+    namespace: linking/static/wolfcrypt
+    author: jakub.jozwiak@mandiant.com
+    scope: file
+    mbc:
+      - Cryptography::Crypto Library [C0059]
+    references:
+      - https://www.wolfssl.com/products/wolfcrypt-2/
+      - https://github.com/wolfSSL/wolfssl/blob/master/wolfcrypt/src/error.c
+    examples:
+      - 5789181cba467fa940cdce809b88b9bf7e0e9d4e079e32a68d2b911a8cc47da9
+  features:
+    - or:
+      - string: "mp_init error state"
+      - string: "wolfcrypt cleanup failed"
+      - string: "Async Init error"
+      - string: "Compress Init error"
+      - string: "wolfCrypt Initialize Failure error"
+      - string: "wolfCrypt operation not pending error"

--- a/linking/static/wolfssl/linked-against-wolfssl.yml
+++ b/linking/static/wolfssl/linked-against-wolfssl.yml
@@ -1,0 +1,24 @@
+rule:
+  meta:
+    name: linked against wolfSSL
+    namespace: linking/static/wolfssl
+    author: jakub.jozwiak@mandiant.com
+    scope: file
+    mbc:
+      - Cryptography::Crypto Library [C0059]
+    references:
+      - https://www.wolfssl.com/
+      - https://github.com/wolfSSL/wolfssl/blob/2841b5c93b87311dadcf2278151df7453e56db96/wolfssl/internal.h#L4646
+    examples:
+      - 5789181cba467fa940cdce809b88b9bf7e0e9d4e079e32a68d2b911a8cc47da9
+  features:
+    - or:
+      - string: "SSLeay wolfSSL compatibility"
+      - string: "wolfSSL_Init"
+      - string: "Please supply a buffer for error string"
+      - 3 or more:
+        - substring: "CLNTSRVR"
+        - substring: "server finished"
+        - substring: "client finished"
+        - substring: "DOGNGRD"
+        - substring: "DOWNGRD"


### PR DESCRIPTION
This PR adds two new rules that match on strings found in binaries statically linked with wolfSSL or wolfCrypt.
wolfCrypt is a backend library used by wolfSSL but it can also be used separately.
