### PR TITLE
Adding packed-with-pespin.yml

### DIFF
--- a/anti-analysis/packer/pespin/packed-with-pespin.yml
+++ b/anti-analysis/packer/pespin/packed-with-pespin.yml
@@ -1,0 +1,19 @@
+rule:
+  meta:
+    name: packed with PESpin
+    namespace: anti-analysis/packer/pespin
+    author: jakub.jozwiak@mandiant.com
+    scope: file
+    att&ck:
+      - Defense Evasion::Obfuscated Files or Information::Software Packing [T1027.002]
+    mbc:
+      - Anti-Static Analysis::Software Packing [F0001]
+    references:
+      - https://www.hexacorn.com/blog/2016/12/15/pe-section-names-re-visited/
+    examples:
+      - 23e19068ecba68d4396bc097e0278b8eca7e7dcaa4978e34d683231ad2219ae3
+      - 4b796a64abe7675254cd6f8a6c9b83949673158840a4a04c36e7c9068ec14cc8
+  features:
+    - or:
+      - section: .taz
+      - section: .x64


### PR DESCRIPTION
This PR adds a new rule that matches on PE section names created by PESpin/PESpin x64 packers.
