### PR TITLE
updating download-url-to-file.yml

### DIFF
--- a/communication/http/client/download-url.yml
+++ b/communication/http/client/download-url.yml
@@ -1,8 +1,10 @@
 rule:
   meta:
-    name: download URL to file
+    name: download URL
     namespace: communication/http/client
-    author: matthew.williams@mandiant.com
+    author:
+      - matthew.williams@mandiant.com
+      - michael.hunhoff@mandiant.com
     scope: function
     mbc:
       - Communication::HTTP Communication::Download URL [C0002.006]
@@ -13,3 +15,6 @@ rule:
     - or:
       - api: urlmon.URLDownloadToFile
       - api: urlmon.URLDownloadToCacheFile
+      - api: urlmon.URLOpenBlockingStream
+      - api: urlmon.URLOpenPullStream
+      - api: urlmon.URLOpenStream

--- a/communication/receive-data.yml
+++ b/communication/receive-data.yml
@@ -13,4 +13,4 @@ rule:
     - or:
       - match: receive data on socket
       - match: read data from Internet
-      - match: download URL to file
+      - match: download URL


### PR DESCRIPTION
renaming and adding new APIs to `download-url-to-file.yml`. closes #496.