### PR TITLE
update mappings for mbc (part 7)

### DIFF
--- a/collection/get-current-user-on-linux.yml
+++ b/collection/get-current-user-on-linux.yml
@@ -4,6 +4,8 @@ rule:
     namespace: collection
     author: joakim@intezer.com
     scope: function
+    att&ck:
+      - Discovery::System Owner/User Discovery [T1033]
     examples:
       - 7351f8a40c5450557b24622417fc478d:0x405438
   features:

--- a/communication/socket/tcp/send/obtain-transmitpackets-callback-function-via-wsaioctl.yml
+++ b/communication/socket/tcp/send/obtain-transmitpackets-callback-function-via-wsaioctl.yml
@@ -5,6 +5,8 @@ rule:
     author: jonathan.lepore@mandiant.com
     description: The TransmitPackets function transmits in-memory data or file data over a connected socket. The TransmitPackets function uses the operating system cache manager to retrieve file data, locking memory for the minimum time required to transmit and resulting in efficient, high-performance transmission.
     scope: function
+    mbc:
+      - Communication::Socket Communication::Send TCP Data [C0001.014]
     references: https://docs.microsoft.com/en-us/windows/win32/api/mswsock/nc-mswsock-lpfn_transmitpackets
     examples:
       - 138C71E94961FE9E31CEC5DFBA62A639:0x100FF55

--- a/host-interaction/bootloader/manipulate-boot-configuration.yml
+++ b/host-interaction/bootloader/manipulate-boot-configuration.yml
@@ -4,6 +4,8 @@ rule:
     namespace: host-interaction/bootloader
     author: william.ballenthin@mandiant.com
     scope: function
+    att&ck:
+      - Defense Evasion::Impair Defenses [T1562]
     references:
       - https://docs.microsoft.com/en-us/windows-hardware/manufacture/desktop/bcdedit-command-line-options
     examples:

--- a/host-interaction/bootloader/manipulate-boot-configuration.yml
+++ b/host-interaction/bootloader/manipulate-boot-configuration.yml
@@ -4,8 +4,6 @@ rule:
     namespace: host-interaction/bootloader
     author: william.ballenthin@mandiant.com
     scope: function
-    att&ck:
-      - Defense Evasion::Impair Defenses [T1562]
     references:
       - https://docs.microsoft.com/en-us/windows-hardware/manufacture/desktop/bcdedit-command-line-options
     examples:

--- a/host-interaction/file-system/change-file-permission-on-linux.yml
+++ b/host-interaction/file-system/change-file-permission-on-linux.yml
@@ -4,6 +4,8 @@ rule:
     namespace: host-interaction/file-system
     author: joakim@intezer.com
     scope: basic block
+    mbc:
+      - File System::Set File Attributes [C0050]
     examples:
       - 7351f8a40c5450557b24622417fc478d:0x407C68
   features:

--- a/host-interaction/log/clfs/read-data-from-clfs-log-container.yml
+++ b/host-interaction/log/clfs/read-data-from-clfs-log-container.yml
@@ -5,6 +5,8 @@ rule:
     namespace: host-interaction/log/clfs/read
     author: blaine.stancill@mandiant.com
     scope: function
+    mbc:
+      - Discovery::File and Directory Discovery::Log File [E1083.m01]
     references:
       - https://docs.microsoft.com/en-us/windows/win32/api/clfsw32/
       - https://github.com/libyal/libfsclfs/blob/main/documenation/Common%20Log%20File%20System%20(CLFS).asciidoc

--- a/host-interaction/recycle-bin/empty-recycle-bin-quietly.yml
+++ b/host-interaction/recycle-bin/empty-recycle-bin-quietly.yml
@@ -4,6 +4,8 @@ rule:
     namespace: host-interaction/recycle-bin
     author: matthew.williams@mandiant.com
     scope: basic block
+    att&ck:
+      - Defense Evasion::Indicator Removal on Host [T1070]
     references:
       - https://docs.microsoft.com/en-us/windows/win32/api/shellapi/nf-shellapi-shemptyrecyclebina
     examples:

--- a/load-code/shellcode/execute-shellcode-via-enumuilanguages.yml
+++ b/load-code/shellcode/execute-shellcode-via-enumuilanguages.yml
@@ -4,6 +4,8 @@ rule:
     namespace: load-code/shellcode
     author: jakub.jozwiak@mandiant.com
     scope: function
+    mbc:
+      - Defense Evasion::Hijack Execution Flow::Abuse Windows Function Calls [F0015.006]
     references:
       - http://ropgadget.com/posts/abusing_win_functions.html
       - https://github.com/S4R1N/AlternativeShellcodeExec/blob/master/EnumUILanguagesW/EnumUILanguagesW.cpp

--- a/load-code/shellcode/execute-shellcode-via-windows-fibers.yml
+++ b/load-code/shellcode/execute-shellcode-via-windows-fibers.yml
@@ -4,6 +4,8 @@ rule:
     namespace: load-code/shellcode
     author: jakub.jozwiak@mandiant.com
     scope: function
+    mbc:
+      - Defense Evasion::Process Injection::Injection via Windows Fibers [E1055.m05]
     references:
       - https://www.ired.team/offensive-security/code-injection-process-injection/executing-shellcode-with-createfiber
       - https://github.com/S4R1N/AlternativeShellcodeExec/blob/master/FiberContextEdit/Source.cpp

--- a/load-code/shellcode/spawn-thread-to-rwx-shellcode.yml
+++ b/load-code/shellcode/spawn-thread-to-rwx-shellcode.yml
@@ -5,8 +5,8 @@ rule:
     author: moritz.raabe@mandiant.com
     scope: function
     mbc:
-     - Memory::Allocate Memory [C0007]
-     - Process::Create Thread [C0038]
+      - Memory::Allocate Memory [C0007]
+      - Process::Create Thread [C0038]
     examples:
       - Practical Malware Analysis Lab 19-02.exe_:0x401230
   features:

--- a/load-code/shellcode/spawn-thread-to-rwx-shellcode.yml
+++ b/load-code/shellcode/spawn-thread-to-rwx-shellcode.yml
@@ -4,6 +4,9 @@ rule:
     namespace: load-code/shellcode
     author: moritz.raabe@mandiant.com
     scope: function
+    mbc:
+     - Memory::Allocate Memory [C0007]
+     - Process::Create Thread [C0038]
     examples:
       - Practical Malware Analysis Lab 19-02.exe_:0x401230
   features:


### PR DESCRIPTION
Looked at capa rules and found a few newer rules without MBC/ATT&CK mappings. Please consider these suggested mappings.

<!--
Thank you for contributing to capa! <3

Please ensure that:
1. each rule passes thorough linting (in rules directory: `python ../scripts/lint.py --thorough -t "<your rule name>" -v .`)
2. you've uploaded each referenced example binary (optional, but greatly appreciated) to https://github.com/fireeye/capa-testfiles

Please mention the issue your PR addresses (if any):
closes #issue_number
-->
