### PR TITLE
Updated and graduated spoof-parent-pid.yml

### DIFF
--- a/anti-analysis/anti-forensic/spoof-parent-pid.yml
+++ b/anti-analysis/anti-forensic/spoof-parent-pid.yml
@@ -5,7 +5,11 @@ rule:
     namespace: anti-analysis/anti-forensic
     author: michael.hunhoff@mandiant.com
     scope: basic block
+    att&ck:
+      - Defense Evasion::Access Token Manipulation::Parent PID Spoofing [T1134.004]
     references: https://blog.f-secure.com/detecting-parent-pid-spoofing/
+    examples:
+      - 2ebadd04f0ada89c36c1409b6e96423a68dd77b513db8db3da203c36d3753e5f:0x140002291
   features:
     - and:
       - api: kernel32.UpdateProcThreadAttribute


### PR DESCRIPTION
Added example and attack mapping to spoof-parent-pid.yml. Moved to anti-analysis/anti-forensic from nursery.

