### PR TITLE
Adding protect-spawned-processes-with-mitigation-policies.yml

### DIFF
--- a/anti-analysis/anti-av/protect-spawned-processes-with-mitigation-policies.yml
+++ b/anti-analysis/anti-av/protect-spawned-processes-with-mitigation-policies.yml
@@ -1,0 +1,25 @@
+rule:
+  meta:
+    name: protect spawned processes with mitigation policies
+    namespace: anti-analysis/anti-av
+    author: jakub.jozwiak@mandiant.com
+    scope: basic block
+    att&ck:
+      - Defense Evasion::Impair Defenses::Disable or Modify Tools [T1562.001]
+    mbc:
+      - Defense Evasion::Impair Defenses::Disable or Modify Tools [OB0006.F0004]
+    references:
+      - https://blog.xpnsec.com/protecting-your-malware/
+      - https://github.com/byt3bl33d3r/OffensiveNim/blob/master/src/blockdlls_acg_ppid_spoof_bin.nim
+    examples:
+      - 2ebadd04f0ada89c36c1409b6e96423a68dd77b513db8db3da203c36d3753e5f:0x140002120
+  features:
+    - and:
+      - api: UpdateProcThreadAttribute
+      - number: 0x20007 = PROC_THREAD_ATTRIBUTE_MITIGATION_POLICY
+      - or:
+        - number: 0x1000000000 = PROCESS_CREATION_MITIGATION_POLICY_PROHIBIT_DYNAMIC_CODE_ALWAYS_ON
+        - number: 0x100000000000 = PROCESS_CREATION_MITIGATION_POLICY_BLOCK_NON_MICROSOFT_BINARIES_ALWAYS_ON
+        - number: 0x300000000000 = PROCESS_CREATION_MITIGATION_POLICY_BLOCK_NON_MICROSOFT_BINARIES_ALLOW_STORE
+        - number: 0x101000000000
+        - number: 0x301000000000


### PR DESCRIPTION
New rule that identifies use of UpdateProcThreadAttribute to enable "BlockDLLs" and Arbitrary Code Guard mitigation policies on spawned processes