### PR TITLE
Fix Mitre Att&ck technique naming

### DIFF
--- a/anti-analysis/packer/gopacker/packed-with-gopacker.yml
+++ b/anti-analysis/packer/gopacker/packed-with-gopacker.yml
@@ -6,7 +6,7 @@ rule:
     description: The sample appears to be packed with GoPacker.
     scope: file
     att&ck:
-      - Defense Evasion::Obfuscated Files or Information [T1027.002]
+      - Defense Evasion::Obfuscated Files or Information::Software Packing [T1027.002]
     mbc:
       - Anti-Static Analysis::Software Packing::Standard Compression [OB0002.F0001.002]
     references:

--- a/host-interaction/network/domain/enumerate-domain-computers-via-ldap.yml
+++ b/host-interaction/network/domain/enumerate-domain-computers-via-ldap.yml
@@ -6,7 +6,7 @@ rule:
     description: Looks for an LDAP query and related Windows API calls used to enumerate other computers on the Windows domain that a computer is connected to.
     scope: function
     att&ck:
-      - Discovery::System Network Configuration Discovery  [T1016]
+      - Discovery::System Network Configuration Discovery [T1016]
     references:
       - https://docs.microsoft.com/en-us/windows/win32/api/adshlp/nf-adshlp-adsopenobject
       - https://www.vkremez.com/2017/12/lets-learn-introducing-new-trickbot.html

--- a/host-interaction/network/domain/get-domain-controller-name.yml
+++ b/host-interaction/network/domain/get-domain-controller-name.yml
@@ -6,7 +6,7 @@ rule:
     description: Looks for calls to Windows APIs that can be used to determine the name of the domain controller for a Windows domain that a computer is connected to.
     scope: function
     att&ck:
-      - Discovery::System Network Configuration Discovery  [T1016]
+      - Discovery::System Network Configuration Discovery [T1016]
     references:
       - https://docs.microsoft.com/en-us/windows/win32/api/lmaccess/nf-lmaccess-netgetdcname
       - https://docs.microsoft.com/en-us/windows/win32/api/dsgetdc/nf-dsgetdc-dsgetdcnamea

--- a/nursery/list-domain-servers.yml
+++ b/nursery/list-domain-servers.yml
@@ -6,7 +6,7 @@ rule:
     author: michael.hunhoff@mandiant.com
     scope: basic block
     att&ck:
-      - Discovery::System Network Configuration Discovery [T1016.001]
+      - Discovery::System Network Configuration Discovery::Internet Connection Discovery [T1016.001]
   features:
     - or:
       - api: netapi32.NetServerEnum

--- a/nursery/monitor-local-ipv4-address-changes.yml
+++ b/nursery/monitor-local-ipv4-address-changes.yml
@@ -6,7 +6,7 @@ rule:
     author: michael.hunhoff@mandiant.com
     scope: basic block
     att&ck:
-      - Discover::System Network Configuration Discovery  [T1016]
+      - Discovery::System Network Configuration Discovery [T1016]
   features:
     - and:
       - api: iphlpapi.NotifyAddrChange

--- a/nursery/schedule-task-via-itaskservice.yml
+++ b/nursery/schedule-task-via-itaskservice.yml
@@ -5,7 +5,7 @@ rule:
     author: michael.hunhoff@mandiant.com
     scope: function
     att&ck:
-      - Persistence/Scheduled Task/Job/Scheduled Task [T1053.005]
+      - Persistence::Scheduled Task/Job::Scheduled Task [T1053.005]
   features:
     - and:
       - basic block:


### PR DESCRIPTION
This PR is related to [WIP - Validate ATT&CK/MBC categories and IDs #875](https://github.com/mandiant/capa/pull/875).

It fixes typo in Mitre Att&ck fields of capa rules.
