### PR TITLE
Adding block-operations-on-executable-memory-pages-using-arbitrary-code-guard.yml

### DIFF
--- a/anti-analysis/anti-av/block-operations-on-executable-memory-pages-using-arbitrary-code-guard.yml
+++ b/anti-analysis/anti-av/block-operations-on-executable-memory-pages-using-arbitrary-code-guard.yml
@@ -1,0 +1,23 @@
+rule:
+  meta:
+    name: block operations on executable memory pages using Arbitrary Code Guard
+    namespace: anti-analysis/anti-av
+    author: jakub.jozwiak@mandiant.com
+    scope: basic block
+    att&ck:
+      - Defense Evasion::Impair Defenses::Disable or Modify Tools [T1562.001]
+    mbc:
+      - Defense Evasion::Impair Defenses::Disable or Modify Tools [OB0006.F0004]
+    references:
+      - https://blog.xpnsec.com/protecting-your-malware/
+      - https://blogs.windows.com/msedgedev/2017/02/23/mitigating-arbitrary-native-code-execution/
+    examples:
+      - 2ebadd04f0ada89c36c1409b6e96423a68dd77b513db8db3da203c36d3753e5f:0x140002120
+  features:
+    - and:
+      - api: SetProcessMitigationPolicy
+      - number: 4 = sizeof(PROCESS_MITIGATION_DYNAMIC_CODE_POLICY)
+      - number: 1 = ProhibitDynamicCode
+      - or:
+        - number: 8 = ProcessDynamicCodePolicy
+        - offset: 4


### PR DESCRIPTION
New rule that identifies use of SetProcessMitigationPolicy to set dynamic code policy (Arbitrary Code Guard) of the process to prevent it from creating and modifying code pages in memory - possibly preventing injection of EDR DLLs.
