### PR TITLE
update capture-screenshot.yml

### DIFF
--- a/collection/screenshot/capture-screenshot.yml
+++ b/collection/screenshot/capture-screenshot.yml
@@ -22,9 +22,7 @@ rule:
           - api: user32.GetWindowDC
           - api: user32.GetDC
           - and:
-            - or:
-              - api: gdi32.CreateDCA
-              - api: gdi32.CreateDCW
+            - api: gdi32.CreateDC
             - string: "DISPLAY"
         - or:
           - api: gdi32.BitBlt

--- a/collection/screenshot/capture-screenshot.yml
+++ b/collection/screenshot/capture-screenshot.yml
@@ -22,7 +22,9 @@ rule:
           - api: user32.GetWindowDC
           - api: user32.GetDC
           - and:
-            - api: gdi32.CreateDCA
+            - or:
+              - api: gdi32.CreateDCA
+              - api: gdi32.CreateDCW
             - string: "DISPLAY"
         - or:
           - api: gdi32.BitBlt


### PR DESCRIPTION
rule missed on a sample that used the wide character flavor API `CreateDCW`.