### PR TITLE
Fix MBC names and IDs

### DIFF
--- a/anti-analysis/anti-av/block-operations-on-executable-memory-pages-using-arbitrary-code-guard.yml
+++ b/anti-analysis/anti-av/block-operations-on-executable-memory-pages-using-arbitrary-code-guard.yml
@@ -7,7 +7,7 @@ rule:
     att&ck:
       - Defense Evasion::Impair Defenses::Disable or Modify Tools [T1562.001]
     mbc:
-      - Defense Evasion::Impair Defenses::Disable or Modify Tools [OB0006.F0004]
+      - Defense Evasion::Disable or Evade Security Tools::Modify Policy [F0004.005]
     references:
       - https://blog.xpnsec.com/protecting-your-malware/
       - https://blogs.windows.com/msedgedev/2017/02/23/mitigating-arbitrary-native-code-execution/

--- a/anti-analysis/anti-av/protect-spawned-processes-with-mitigation-policies.yml
+++ b/anti-analysis/anti-av/protect-spawned-processes-with-mitigation-policies.yml
@@ -7,7 +7,7 @@ rule:
     att&ck:
       - Defense Evasion::Impair Defenses::Disable or Modify Tools [T1562.001]
     mbc:
-      - Defense Evasion::Impair Defenses::Disable or Modify Tools [OB0006.F0004]
+      - Defense Evasion::Disable or Evade Security Tools::Modify Policy [F0004.005]
     references:
       - https://blog.xpnsec.com/protecting-your-malware/
       - https://github.com/byt3bl33d3r/OffensiveNim/blob/master/src/blockdlls_acg_ppid_spoof_bin.nim

--- a/anti-analysis/anti-debugging/debugger-detection/check-processdebugport.yml
+++ b/anti-analysis/anti-debugging/debugger-detection/check-processdebugport.yml
@@ -5,7 +5,7 @@ rule:
     author: michael.hunhoff@mandiant.com
     scope: basic block
     mbc:
-      - Anti-Behavioral Analysis::Debugger Detection
+      - Anti-Behavioral Analysis::Debugger Detection::NtQueryInformationProcess [B0001.012]
     references:
       - https://github.com/LordNoteworthy/al-khaser/blob/master/al-khaser/AntiDebug/NtQueryInformationProcess_ProcessDebugPort.cpp
     examples:

--- a/anti-analysis/anti-vm/vm-detection/check-for-microsoft-office-emulation.yml
+++ b/anti-analysis/anti-vm/vm-detection/check-for-microsoft-office-emulation.yml
@@ -7,7 +7,7 @@ rule:
     att&ck:
       - Defense Evasion::Virtualization/Sandbox Evasion::System Checks [T1497.001]
     mbc:
-      - Anti-Behavioral Analysis::Virtual Machine Detection::Product Key/ID Testing [B0007.005]
+      - Anti-Behavioral Analysis::Sandbox Detection::Product Key/ID Testing [B0007.005]
     references:
       - https://github.com/LloydLabs/wsb-detect
     examples:

--- a/anti-analysis/packer/gopacker/packed-with-gopacker.yml
+++ b/anti-analysis/packer/gopacker/packed-with-gopacker.yml
@@ -8,7 +8,7 @@ rule:
     att&ck:
       - Defense Evasion::Obfuscated Files or Information::Software Packing [T1027.002]
     mbc:
-      - Anti-Static Analysis::Software Packing::Standard Compression [OB0002.F0001.002]
+      - Anti-Static Analysis::Software Packing::Standard Compression [F0001.002]
     references:
       - https://github.com/nirhaas/gopacker
     examples:

--- a/anti-analysis/reference-analysis-tools-strings.yml
+++ b/anti-analysis/reference-analysis-tools-strings.yml
@@ -5,7 +5,7 @@ rule:
     author: michael.hunhoff@mandiant.com
     scope: file
     mbc:
-      - Discovery::Analysis Tool Discovery::Process Detection [B0013.001]
+      - Discovery::Analysis Tool Discovery::Process detection [B0013.001]
     references:
       - https://github.com/LordNoteworthy/al-khaser/blob/master/al-khaser/AntiAnalysis/process.cpp
     examples:

--- a/host-interaction/process/dump/create-process-memory-minidump.yml
+++ b/host-interaction/process/dump/create-process-memory-minidump.yml
@@ -6,7 +6,7 @@ rule:
     author: michael.hunhoff@mandiant.com
     scope: basic block
     mbc:
-      - File System::Write File [C0052]
+      - File System::Writes File [C0052]
     examples:
       - 91a12a4cf437589ba70b1687f5acad19:0x43E1C9
   features:

--- a/host-interaction/service/run-as-service.yml
+++ b/host-interaction/service/run-as-service.yml
@@ -7,7 +7,7 @@ rule:
       - michael.hunhoff@mandiant.com
     scope: file
     mbc:
-      - Anti-Behavioral Analysis::Execution Guardrails::Runs as Service [E1480.m07]
+      - Anti-Behavioral Analysis::Conditional Execution::Runs as Service [B0025.007]
     examples:
       - Practical Malware Analysis Lab 03-02.dll_
   features:

--- a/impact/inhibit-system-recovery/delete-volume-shadow-copies.yml
+++ b/impact/inhibit-system-recovery/delete-volume-shadow-copies.yml
@@ -8,7 +8,7 @@ rule:
       - Impact::Inhibit System Recovery [T1490]
       - Defense Evasion::Indicator Removal on Host::File Deletion [T1070.004]
     mbc:
-      - Impact::Disk Content Wipe::Delete Shadow Drive [F0014.001]
+      - Impact::Data Destruction::Delete Shadow Copies [E1485.m04]
     examples:
       - B87E9DD18A5533A09D3E48A7A1EFBCF6:0x140006AF0
   features:

--- a/load-code/pe/rebuild-import-table.yml
+++ b/load-code/pe/rebuild-import-table.yml
@@ -5,7 +5,7 @@ rule:
     author: "@Ana06"
     scope: function
     mbc:
-      - Defense Evasion::Hijack Execution Flow::Import Address Table (IAT) Hooking [F0005.m03]
+      - Defense Evasion::Hijack Execution Flow::Import Address Table (IAT) Hooking [F0015.003]
     references:
       - https://0x00sec.org/t/reflective-dll-injection/3080
       - https://www.ired.team/offensive-security/code-injection-process-injection/reflective-dll-injection

--- a/nursery/check-for-process-debug-object.yml
+++ b/nursery/check-for-process-debug-object.yml
@@ -5,7 +5,7 @@ rule:
     author: michael.hunhoff@mandiant.com
     scope: function
     mbc:
-      - Anti-Behavioral Analysis::Debugger Detection
+      - Anti-Behavioral Analysis::Debugger Detection::NtQueryInformationProcess [B0001.012]
     references:
       - https://github.com/LordNoteworthy/al-khaser/blob/master/al-khaser/AntiDebug/NtQueryInformationProcess_ProcessDebugObject.cpp
   features:

--- a/nursery/check-processdebugflags.yml
+++ b/nursery/check-processdebugflags.yml
@@ -5,7 +5,7 @@ rule:
     author: michael.hunhoff@mandiant.com
     scope: basic block
     mbc:
-      - Anti-Behavioral Analysis::Debugger Detection
+      - Anti-Behavioral Analysis::Debugger Detection::NtQueryInformationProcess [B0001.012]
     references:
       - https://github.com/LordNoteworthy/al-khaser/blob/master/al-khaser/AntiDebug/NtQueryInformationProcess_ProcessDebugFlags.cpp
   features:

--- a/nursery/check-systemkerneldebuggerinformation.yml
+++ b/nursery/check-systemkerneldebuggerinformation.yml
@@ -5,7 +5,7 @@ rule:
     author: michael.hunhoff@mandiant.com
     scope: basic block
     mbc:
-      - Anti-Behavioral Analysis::Debugger Detection
+      - Anti-Behavioral Analysis::Debugger Detection::NtQueryInformationProcess [B0001.012]
     references:
       - https://github.com/LordNoteworthy/al-khaser/blob/master/al-khaser/AntiDebug/NtQuerySystemInformation_SystemKernelDebuggerInformation.cpp
   features:

--- a/nursery/check-thread-yield-allowed.yml
+++ b/nursery/check-thread-yield-allowed.yml
@@ -5,7 +5,7 @@ rule:
     author: michael.hunhoff@mandiant.com
     scope: function
     mbc:
-      - Anti-Behavioral Analysis::Debugger Detection
+      - Anti-Behavioral Analysis::Debugger Detection::NtYieldExecution/SwitchToThread [B0001.015]
     references:
       - https://github.com/LordNoteworthy/al-khaser/blob/master/al-khaser/AntiDebug/NtYieldExecution.cpp
   features:


### PR DESCRIPTION
This PR fixes MBC names and IDs in the continuity of #524.

In my second commit, I've made names/IDs changes that could have more impacts and which are only based on my thoughts. Some MBC categories are not present anymore and sometime a method could be associated to the behavior. 
Here are the rules I am talking about if you want to discuss the changes: 
| Capa rule  | MBC |
| ------------- | ------------- |
| Rule “protect spawned processes with mitigation policies” | Defense Evasion::Disable or Evade Security Tools::Modify Policy [F0004.005] |
| Rule “block operations on executable memory pages using Arbitrary Code Guard” | Defense Evasion::Disable or Evade Security Tools::Modify Policy [F0004.005]
| Rule “check for process debug object” | Anti-Behavioral Analysis::Debugger Detection::NtQueryInformationProcess [B0001.012]
| Rule “check ProcessDebugFlags” | Anti-Behavioral Analysis::Debugger Detection::NtQueryInformationProcess [B0001.012]
| Rule “check SystemKernelDebuggerInformation” | Anti-Behavioral Analysis::Debugger Detection::NtQueryInformationProcess [B0001.012]
| Rule“check ProcessDebugPort” | Anti-Behavioral Analysis::Debugger Detection::NtQueryInformationProcess [B0001.012]
| Rule “run as service” | Anti-Behavioral Analysis::Conditional Execution::Runs as Service [B0025.007]
| Rule “check thread yield allowed” | Anti-Behavioral Analysis::Debugger Detection::NtYieldExecution/SwitchToThread [B0001.015]
