### PR TITLE
Update create-process-on-windows.yml mapping to ATT&CK T1106

### DIFF
--- a/host-interaction/process/create/create-process-on-windows.yml
+++ b/host-interaction/process/create/create-process-on-windows.yml
@@ -5,6 +5,8 @@ rule:
     author:
       - moritz.raabe@mandiant.com
     scope: basic block
+    att&ck:
+      - Execution::Native API [T1106]
     mbc:
       - Process::Create Process [C0017]
     examples:


### PR DESCRIPTION
Just adding the att&ck category for T1106 to the create-process-on-windows.yml rule.
I think this makes sense for the Windows rule.

https://attack.mitre.org/techniques/T1106/

<!--
Thank you for contributing to capa! <3

Please ensure that:
1. each rule passes thorough linting (in rules directory: `python ../scripts/lint.py --thorough -t "<your rule name>" -v .`)
2. you've uploaded each referenced example binary (optional, but greatly appreciated) to https://github.com/fireeye/capa-testfiles

Please mention the issue your PR addresses (if any):
closes #issue_number
-->
