### PR TITLE
Minor update to anti-debug GetTickCount rule

### DIFF
--- a/anti-analysis/anti-debugging/debugger-detection/check-for-time-delay-via-gettickcount.yml
+++ b/anti-analysis/anti-debugging/debugger-detection/check-for-time-delay-via-gettickcount.yml
@@ -11,3 +11,7 @@ rule:
   features:
     - and:
       - count(api(kernel32.GetTickCount)): 2 or more
+      - basic block:
+        - and:
+          - mnemonic: sub
+          - mnemonic: cmp


### PR DESCRIPTION
Added `sub` and `cmp` mnemonics to capture the `GetTickCount` values comparison. The updated rule works with the example file.
