### PR TITLE
Adding compiled-with-v.yml and compiled-with-zig.yml

### DIFF
--- a/compiler/v/compiled-with-v.yml
+++ b/compiler/v/compiled-with-v.yml
@@ -1,0 +1,22 @@
+rule:
+  meta:
+    name: compiled with V
+    namespace: compiler/v
+    author: jakub.jozwiak@mandiant.com
+    scope: file
+    references:
+      - https://vlang.io
+      - https://github.com/vlang/v
+    examples:
+      - e87076a1182ba40758e1d7258442c1ee23bf71ac77fad9f3babc707dce11c144
+  features:
+    - or:
+      - string: "================ V panic ================"
+      - string: "V_RESOURCE_PATH"
+      - 5 or more:
+        - substring: "v_error:"
+        - substring: "v_exit:"
+        - substring: "v_free:"
+        - substring: "v_malloc:"
+        - substring: "v_panic"
+        - substring: "v_realloc"

--- a/compiler/zig/compiled-with-zig.yml
+++ b/compiler/zig/compiled-with-zig.yml
@@ -10,16 +10,13 @@ rule:
     examples:
       - 74e0758e469ab87f38cda7925d696ea41a122364891860e1ae30fc9ff2f68e7d
   features:
-    - and:
-      - function:
-        - or:
-          - api: ntdll.NtLockFile
-          - api: ntdll.NtCreateFile
-          - api: ntdll.NtClose
-          - api: ntdll.NtCreateKeyedEvent
-          - api: ntdll.NtWaitForKeyedEvent
-      - or:
-        - string: "ZIG_DEBUG_COLOR"
-        - string: "Panicked during a panic. Aborting."
-        - string: "error.Unexpected NTSTATUS=0x{x}"
-        - string: "Unable to dump stack trace: debug info stripped"
+    - 2 or more:
+      - string: "ZIG_DEBUG_COLOR"
+      - string: "Panicked during a panic. Aborting."
+      - string: "error.Unexpected NTSTATUS=0x{x}"
+      - string: "Unable to dump stack trace: debug info stripped"
+      - string: "Unable to dump stack trace: Unable to open debug info: {s}"
+      - string: "Unable to dump stack trace: {s}"
+      - string: "std.mem.Allocator.alloc"
+      - string: "_std.os.getenv"
+      - string: "\\\\.\\pipe\\zig-childprocess-{d}-{d}"

--- a/compiler/zig/compiled-with-zig.yml
+++ b/compiler/zig/compiled-with-zig.yml
@@ -1,0 +1,25 @@
+rule:
+  meta:
+    name: compiled with Zig
+    namespace: compiler/zig
+    author: jakub.jozwiak@mandiant.com
+    scope: file
+    references:
+      - https://ziglang.org
+      - https://github.com/ziglang/zig
+    examples:
+      - 74e0758e469ab87f38cda7925d696ea41a122364891860e1ae30fc9ff2f68e7d
+  features:
+    - and:
+      - function:
+        - or:
+          - api: ntdll.NtLockFile
+          - api: ntdll.NtCreateFile
+          - api: ntdll.NtClose
+          - api: ntdll.NtCreateKeyedEvent
+          - api: ntdll.NtWaitForKeyedEvent
+      - or:
+        - string: "ZIG_DEBUG_COLOR"
+        - string: "Panicked during a panic. Aborting."
+        - string: "error.Unexpected NTSTATUS=0x{x}"
+        - string: "Unable to dump stack trace: debug info stripped"


### PR DESCRIPTION
New rules that identify executables compiled with V(lang) and Zig(lang).