### PR TITLE
Update rules to use a list item instead of a string value for reference

### DIFF
--- a/anti-analysis/anti-forensic/spoof-parent-pid.yml
+++ b/anti-analysis/anti-forensic/spoof-parent-pid.yml
@@ -7,7 +7,8 @@ rule:
     scope: basic block
     att&ck:
       - Defense Evasion::Access Token Manipulation::Parent PID Spoofing [T1134.004]
-    references: https://blog.f-secure.com/detecting-parent-pid-spoofing/
+    references:
+      - https://blog.f-secure.com/detecting-parent-pid-spoofing/
     examples:
       - 2ebadd04f0ada89c36c1409b6e96423a68dd77b513db8db3da203c36d3753e5f:0x140002291
   features:

--- a/communication/socket/tcp/send/obtain-transmitpackets-callback-function-via-wsaioctl.yml
+++ b/communication/socket/tcp/send/obtain-transmitpackets-callback-function-via-wsaioctl.yml
@@ -7,7 +7,8 @@ rule:
     scope: function
     mbc:
       - Communication::Socket Communication::Send TCP Data [C0001.014]
-    references: https://docs.microsoft.com/en-us/windows/win32/api/mswsock/nc-mswsock-lpfn_transmitpackets
+    references:
+      - https://docs.microsoft.com/en-us/windows/win32/api/mswsock/nc-mswsock-lpfn_transmitpackets
     examples:
       - 138C71E94961FE9E31CEC5DFBA62A639:0x100FF55
   features:

--- a/data-manipulation/encryption/hc-128/encrypt-data-using-hc-128-via-wolfssl.yml
+++ b/data-manipulation/encryption/hc-128/encrypt-data-using-hc-128-via-wolfssl.yml
@@ -10,7 +10,8 @@ rule:
     mbc:
       - Defense Evasion::Obfuscated Files or Information::Encryption-Standard Algorithm [E1027.m05]
       - Cryptography::Encrypt Data::HC-128 [C0027.006]
-    references: https://github.com/wolfSSL/wolfssl/blob/6694775d4b8c22e7411ec69e8a2b516f107b97ef/wolfcrypt/src/hc128.c
+    references:
+      - https://github.com/wolfSSL/wolfssl/blob/6694775d4b8c22e7411ec69e8a2b516f107b97ef/wolfcrypt/src/hc128.c
     examples:
       - 91B08896FBDA9EDB8B6F93A6BC811EC6:0x180003562
   features:

--- a/doc/format.md
+++ b/doc/format.md
@@ -138,7 +138,7 @@ The linter verifies that each rule correctly fires on each sample referenced in 
 These example files are stored in the [github.com/mandiant/capa-testfiles](https://github.com/mandiant/capa-testfiles) repository.
 `function` and `basic block` scope rules must contain offsets to the respective match locations using the format `<sample name>:<function or basic block offset>`.
 
-  - `references` lists related information found in a book, article, blog post, etc.
+  - `references` A list of related information found in a book, article, blog post, etc.
 
 Other fields are not allowed, and the linter will complain about them.
 

--- a/nursery/add-file-to-cabinet-file.yml
+++ b/nursery/add-file-to-cabinet-file.yml
@@ -4,7 +4,8 @@ rule:
     namespace: host-interaction/file-system
     author: michael.hunhoff@mandiant.com
     scope: function
-    references: https://docs.microsoft.com/en-us/windows/win32/msi/cabinet-files
+    references:
+      - https://docs.microsoft.com/en-us/windows/win32/msi/cabinet-files
   features:
     - or:
       - api: cabinet.FCIAddFile

--- a/nursery/create-registry-key-via-stdregprov.yml
+++ b/nursery/create-registry-key-via-stdregprov.yml
@@ -5,7 +5,8 @@ rule:
     namespace: host-interaction/registry
     author: michael.hunhoff@mandiant.com
     scope: function
-    references: https://docs.microsoft.com/en-us/previous-versions/windows/desktop/regprov/stdregprov#methods
+    references:
+      - https://docs.microsoft.com/en-us/previous-versions/windows/desktop/regprov/stdregprov#methods
   features:
     - and:
       - string: "StdRegProv"

--- a/nursery/create-restart-manager-session.yml
+++ b/nursery/create-restart-manager-session.yml
@@ -5,7 +5,8 @@ rule:
     author: michael.hunhoff@mandiant.com
     description: Windows Restart Manager can be used to close/unlock specific files, often abused by Ransomware
     scope: function
-    references: https://www.carbonblack.com/blog/tau-threat-discovery-conti-ransomware/
+    references:
+      - https://www.carbonblack.com/blog/tau-threat-discovery-conti-ransomware/
   features:
     - or:
       - api: rstrtmgr.RmStartSession

--- a/nursery/delete-registry-key-via-stdregprov.yml
+++ b/nursery/delete-registry-key-via-stdregprov.yml
@@ -5,7 +5,8 @@ rule:
     namespace: host-interaction/registry
     author: michael.hunhoff@mandiant.com
     scope: function
-    references: https://docs.microsoft.com/en-us/previous-versions/windows/desktop/regprov/stdregprov#methods
+    references:
+      - https://docs.microsoft.com/en-us/previous-versions/windows/desktop/regprov/stdregprov#methods
   features:
     - and:
       - string: "StdRegProv"

--- a/nursery/delete-registry-value-via-stdregprov.yml
+++ b/nursery/delete-registry-value-via-stdregprov.yml
@@ -5,7 +5,8 @@ rule:
     namespace: host-interaction/registry
     author: michael.hunhoff@mandiant.com
     scope: function
-    references: https://docs.microsoft.com/en-us/previous-versions/windows/desktop/regprov/stdregprov#methods
+    references:
+      - https://docs.microsoft.com/en-us/previous-versions/windows/desktop/regprov/stdregprov#methods
   features:
     - and:
       - string: "StdRegProv"

--- a/nursery/encrypt-data-using-fakem-cipher.yml
+++ b/nursery/encrypt-data-using-fakem-cipher.yml
@@ -11,7 +11,8 @@ rule:
     mbc:
       - Cryptography::Decrypt Data [C0031]
       - Cryptography::Encrypt Data [C0027]
-    references: https://attack.mitre.org/software/S0076/
+    references:
+      - https://attack.mitre.org/software/S0076/
   features:
     - and:
       - characteristic: tight loop

--- a/nursery/flush-cabinet-file.yml
+++ b/nursery/flush-cabinet-file.yml
@@ -4,7 +4,8 @@ rule:
     namespace: host-interaction/file-system
     author: michael.hunhoff@mandiant.com
     scope: function
-    references: https://docs.microsoft.com/en-us/windows/win32/msi/cabinet-files
+    references:
+      - https://docs.microsoft.com/en-us/windows/win32/msi/cabinet-files
   features:
     - or:
       - api: cabinet.FCIFlushFolder = flush current folder under construction

--- a/nursery/get-storage-device-properties.yml
+++ b/nursery/get-storage-device-properties.yml
@@ -5,7 +5,8 @@ rule:
     namespace: host-interaction/hardware/storage
     author: michael.hunhoff@mandiant.com
     scope: function
-    references: https://docs.microsoft.com/en-us/windows/win32/api/winioctl/ni-winioctl-ioctl_storage_query_property
+    references:
+      - https://docs.microsoft.com/en-us/windows/win32/api/winioctl/ni-winioctl-ioctl_storage_query_property
   features:
     - and:
       - match: interact with driver via control codes

--- a/nursery/open-cabinet-file.yml
+++ b/nursery/open-cabinet-file.yml
@@ -4,7 +4,8 @@ rule:
     namespace: host-interaction/file-system
     author: michael.hunhoff@mandiant.com
     scope: function
-    references: https://docs.microsoft.com/en-us/windows/win32/msi/cabinet-files
+    references:
+      - https://docs.microsoft.com/en-us/windows/win32/msi/cabinet-files
   features:
     - or:
       - api: cabinet.FCICreate

--- a/nursery/prompt-user-for-credentials.yml
+++ b/nursery/prompt-user-for-credentials.yml
@@ -5,7 +5,8 @@ rule:
     namespace: collection/credentials
     author: michael.hunhoff@mandiant.com
     scope: function
-    references: https://www.ired.team/offensive-security/credential-access-and-credential-dumping/credentials-collection-via-creduipromptforcredentials
+    references:
+      - https://www.ired.team/offensive-security/credential-access-and-credential-dumping/credentials-collection-via-creduipromptforcredentials
   features:
     - and:
       - or:

--- a/nursery/query-or-enumerate-registry-key-via-stdregprov.yml
+++ b/nursery/query-or-enumerate-registry-key-via-stdregprov.yml
@@ -5,7 +5,8 @@ rule:
     namespace: host-interaction/registry
     author: michael.hunhoff@mandiant.com
     scope: function
-    references: https://docs.microsoft.com/en-us/previous-versions/windows/desktop/regprov/stdregprov#methods
+    references:
+      - https://docs.microsoft.com/en-us/previous-versions/windows/desktop/regprov/stdregprov#methods
   features:
     - and:
       - string: "StdRegProv"

--- a/nursery/query-or-enumerate-registry-value-via-stdregprov.yml
+++ b/nursery/query-or-enumerate-registry-value-via-stdregprov.yml
@@ -5,7 +5,8 @@ rule:
     namespace: host-interaction/registry
     author: michael.hunhoff@mandiant.com
     scope: function
-    references: https://docs.microsoft.com/en-us/previous-versions/windows/desktop/regprov/stdregprov#methods
+    references:
+      - https://docs.microsoft.com/en-us/previous-versions/windows/desktop/regprov/stdregprov#methods
   features:
     - and:
       - string: "StdRegProv"

--- a/nursery/set-registry-value-via-stdregprov.yml
+++ b/nursery/set-registry-value-via-stdregprov.yml
@@ -5,7 +5,8 @@ rule:
     namespace: host-interaction/registry
     author: michael.hunhoff@mandiant.com
     scope: function
-    references: https://docs.microsoft.com/en-us/previous-versions/windows/desktop/regprov/stdregprov#methods
+    references:
+      - https://docs.microsoft.com/en-us/previous-versions/windows/desktop/regprov/stdregprov#methods
   features:
     - and:
       - string: "StdRegProv"


### PR DESCRIPTION
Several rules use a string value to define a reference. This can cause issues in calling code as the value may be a list or a string. Checking the defined format states that this field lists related information, so I believe this should always be a list of references. 

Updated format.md to define the field as a list of related info.  
Updated these rules to define the reference value as a list entry. 