### PR TITLE
*: use meta.authors when there's more than one author

### DIFF
--- a/anti-analysis/anti-forensic/patch-process-command-line.yml
+++ b/anti-analysis/anti-forensic/patch-process-command-line.yml
@@ -2,7 +2,7 @@ rule:
   meta:
     name: patch process command line
     namespace: anti-analysis/anti-forensic
-    author:
+    authors:
       - william.ballenthin@mandiant.com
       - "@_re_fox"
     scope: function

--- a/anti-analysis/anti-vm/vm-detection/reference-anti-vm-strings-targeting-vmware.yml
+++ b/anti-analysis/anti-vm/vm-detection/reference-anti-vm-strings-targeting-vmware.yml
@@ -2,7 +2,7 @@ rule:
   meta:
     name: reference anti-VM strings targeting VMWare
     namespace: anti-analysis/anti-vm/vm-detection
-    author:
+    authors:
       - michael.hunhoff@mandiant.com
       - "@johnk3r"
     scope: file

--- a/collection/network/get-mac-address-on-windows.yml
+++ b/collection/network/get-mac-address-on-windows.yml
@@ -2,7 +2,7 @@ rule:
   meta:
     name: get MAC address on Windows
     namespace: collection/network
-    author:
+    authors:
       - moritz.raabe@mandiant.com
     scope: function
     att&ck:

--- a/collection/screenshot/capture-screenshot.yml
+++ b/collection/screenshot/capture-screenshot.yml
@@ -2,7 +2,7 @@ rule:
   meta:
     name: capture screenshot
     namespace: collection/screenshot
-    author:
+    authors:
       - moritz.raabe@mandiant.com
       - "@_re_fox"
       - michael.hunhoff@mandiant.com

--- a/communication/http/client/download-url.yml
+++ b/communication/http/client/download-url.yml
@@ -2,7 +2,7 @@ rule:
   meta:
     name: download URL
     namespace: communication/http/client
-    author:
+    authors:
       - matthew.williams@mandiant.com
       - michael.hunhoff@mandiant.com
     scope: function

--- a/communication/named-pipe/connect/connect-pipe.yml
+++ b/communication/named-pipe/connect/connect-pipe.yml
@@ -2,7 +2,7 @@ rule:
   meta:
     name: connect pipe
     namespace: communication/named-pipe/connect
-    author:
+    authors:
       - moritz.raabe@mandiant.com
       - michael.hunhoff@mandiant.com
     scope: function

--- a/communication/named-pipe/read/read-pipe.yml
+++ b/communication/named-pipe/read/read-pipe.yml
@@ -2,7 +2,7 @@ rule:
   meta:
     name: read pipe
     namespace: communication/named-pipe/read
-    author:
+    authors:
       - moritz.raabe@mandiant.com
       - michael.hunhoff@mandiant.com
     description: PeekNamedPipe isn't required to read from a pipe; however, pipes are often utilized to capture the output of a cmd.exe process. In a multi-thread instance, a new thread is created that calls PeekNamedPipe and ReadFile to obtain the command output.

--- a/communication/named-pipe/write/write-pipe.yml
+++ b/communication/named-pipe/write/write-pipe.yml
@@ -2,7 +2,7 @@ rule:
   meta:
     name: write pipe
     namespace: communication/named-pipe/write
-    author:
+    authors:
       - moritz.raabe@mandiant.com
       - michael.hunhoff@mandiant.com
     scope: function

--- a/communication/send-data.yml
+++ b/communication/send-data.yml
@@ -2,7 +2,7 @@ rule:
   meta:
     name: send data
     namespace: communication
-    author:
+    authors:
       - william.ballenthin@mandiant.com
       - joakim@intezer.com
     description: all known techniques for sending data to a potential C2 server

--- a/communication/socket/receive/receive-data-on-socket.yml
+++ b/communication/socket/receive/receive-data-on-socket.yml
@@ -2,7 +2,7 @@ rule:
   meta:
     name: receive data on socket
     namespace: communication/socket/receive
-    author:
+    authors:
       - moritz.raabe@mandiant.com
       - joakim@intezer.com
     scope: function

--- a/communication/socket/send/send-data-on-socket.yml
+++ b/communication/socket/send/send-data-on-socket.yml
@@ -2,7 +2,7 @@ rule:
   meta:
     name: send data on socket
     namespace: communication/socket/send
-    author:
+    authors:
       - moritz.raabe@mandiant.com
       - joakim@intezer.com
     scope: function

--- a/communication/socket/tcp/connect-tcp-socket.yml
+++ b/communication/socket/tcp/connect-tcp-socket.yml
@@ -2,7 +2,7 @@ rule:
   meta:
     name: connect TCP socket
     namespace: communication/socket/tcp
-    author:
+    authors:
       - moritz.raabe@mandiant.com
       - joakim@intezer.com
     scope: function

--- a/communication/socket/tcp/create-tcp-socket.yml
+++ b/communication/socket/tcp/create-tcp-socket.yml
@@ -2,7 +2,7 @@ rule:
   meta:
     name: create TCP socket
     namespace: communication/socket/tcp
-    author:
+    authors:
       - william.ballenthin@mandiant.com
       - joakim@intezer.com
     scope: basic block

--- a/communication/socket/udp/send/create-udp-socket.yml
+++ b/communication/socket/udp/send/create-udp-socket.yml
@@ -2,7 +2,7 @@ rule:
   meta:
     name: create UDP socket
     namespace: communication/socket/udp/send
-    author:
+    authors:
       - moritz.raabe@mandiant.com
       - joakim@intezer.com
     scope: basic block

--- a/data-manipulation/compression/decompress-data-using-aplib.yml
+++ b/data-manipulation/compression/decompress-data-using-aplib.yml
@@ -2,7 +2,7 @@ rule:
   meta:
     name: decompress data using aPLib
     namespace: data-manipulation/compression
-    author:
+    authors:
       - "@r3c0nst (Frank Boldewin)"
       - moritz.raabe@mandiant.com
       - cdong49@gatech.edu

--- a/data-manipulation/hashing/fnv/hash-data-using-fnv.yml
+++ b/data-manipulation/hashing/fnv/hash-data-using-fnv.yml
@@ -2,7 +2,7 @@ rule:
   meta:
     name: hash data using fnv
     namespace: data-manipulation/hashing/fnv
-    author:
+    authors:
       - moritz.raabe@mandiant.com
       - "@_re_fox"
       - michael.hunhoff@mandiant.com

--- a/data-manipulation/prng/generate-random-numbers-via-winapi.yml
+++ b/data-manipulation/prng/generate-random-numbers-via-winapi.yml
@@ -2,7 +2,7 @@ rule:
   meta:
     name: generate random numbers via WinAPI
     namespace: data-manipulation/prng
-    author:
+    authors:
       - michael.hunhoff@mandiant.com
       - johnk3r
     scope: function

--- a/host-interaction/environment-variable/query-environment-variable.yml
+++ b/host-interaction/environment-variable/query-environment-variable.yml
@@ -2,7 +2,7 @@ rule:
   meta:
     name: query environment variable
     namespace: host-interaction/environment-variable
-    author:
+    authors:
       - michael.hunhoff@mandiant.com
       - "@_re_fox"
     scope: function

--- a/host-interaction/file-system/meta/set-file-attributes.yml
+++ b/host-interaction/file-system/meta/set-file-attributes.yml
@@ -2,7 +2,7 @@ rule:
   meta:
     name: set file attributes
     namespace: host-interaction/file-system/meta
-    author:
+    authors:
       - moritz.raabe@mandiant.com
       - michael.hunhoff@mandiant.com
     scope: basic block

--- a/host-interaction/file-system/read/read-file-on-linux.yml
+++ b/host-interaction/file-system/read/read-file-on-linux.yml
@@ -2,7 +2,7 @@ rule:
   meta:
     name: read file on Linux
     namespace: host-interaction/file-system/read
-    author:
+    authors:
       - joakim@intezer.com
     scope: function
     mbc:

--- a/host-interaction/file-system/read/read-file-on-windows.yml
+++ b/host-interaction/file-system/read/read-file-on-windows.yml
@@ -2,7 +2,7 @@ rule:
   meta:
     name: read file on Windows
     namespace: host-interaction/file-system/read
-    author:
+    authors:
       - moritz.raabe@mandiant.com
     scope: function
     mbc:

--- a/host-interaction/file-system/read/read-ini-file.yml
+++ b/host-interaction/file-system/read/read-ini-file.yml
@@ -2,7 +2,7 @@ rule:
   meta:
     name: read .ini file
     namespace: host-interaction/file-system/read
-    author:
+    authors:
       - "@_re_fox"
       - michael.hunhoff@mandiant.com
     scope: function

--- a/host-interaction/file-system/write/write-file-on-linux.yml
+++ b/host-interaction/file-system/write/write-file-on-linux.yml
@@ -2,7 +2,7 @@ rule:
   meta:
     name: write file on Linux
     namespace: host-interaction/file-system/write
-    author:
+    authors:
       - joakim@intezer.com
     scope: function
     mbc:

--- a/host-interaction/file-system/write/write-file-on-windows.yml
+++ b/host-interaction/file-system/write/write-file-on-windows.yml
@@ -2,7 +2,7 @@ rule:
   meta:
     name: write file on Windows
     namespace: host-interaction/file-system/write
-    author:
+    authors:
       - william.ballenthin@mandiant.com
     scope: function
     mbc:

--- a/host-interaction/hardware/cpu/get-cpu-information.yml
+++ b/host-interaction/hardware/cpu/get-cpu-information.yml
@@ -2,7 +2,7 @@ rule:
   meta:
     name: get CPU information
     namespace: host-interaction/hardware/cpu
-    author:
+    authors:
       - moritz.raabe@mandiant.com
       - joakim@intezer.com
     scope: function

--- a/host-interaction/hardware/keyboard/simulate-ctrl-alt-del.yml
+++ b/host-interaction/hardware/keyboard/simulate-ctrl-alt-del.yml
@@ -2,7 +2,7 @@ rule:
   meta:
     name: simulate CTRL ALT DEL
     namespace: host-interaction/hardware/keyboard
-    author:
+    authors:
       - michael.hunhoff@mandiant.com
       - johnk3r
     scope: function

--- a/host-interaction/mutex/check-mutex-and-exit.yml
+++ b/host-interaction/mutex/check-mutex-and-exit.yml
@@ -2,7 +2,7 @@ rule:
   meta:
     name: check mutex and exit
     namespace: host-interaction/mutex
-    author:
+    authors:
       - "@_re_fox"
       - moritz.raabe@mandiant.com
     scope: function

--- a/host-interaction/network/address/get-local-ipv4-addresses.yml
+++ b/host-interaction/network/address/get-local-ipv4-addresses.yml
@@ -2,7 +2,7 @@ rule:
   meta:
     name: get local IPv4 addresses
     namespace: host-interaction/network/address
-    author:
+    authors:
       - moritz.raabe@mandiant.com
       - joakim@intezer.com
     scope: function

--- a/host-interaction/network/connectivity/check-internet-connectivity-via-wininet.yml
+++ b/host-interaction/network/connectivity/check-internet-connectivity-via-wininet.yml
@@ -2,7 +2,7 @@ rule:
   meta:
     name: check Internet connectivity via WinINet
     namespace: host-interaction/network/connectivity
-    author:
+    authors:
       - matthew.williams@mandiant.com
       - michael.hunhoff@mandiant.com
     scope: basic block

--- a/host-interaction/network/dns/resolve/resolve-dns.yml
+++ b/host-interaction/network/dns/resolve/resolve-dns.yml
@@ -2,7 +2,7 @@ rule:
   meta:
     name: resolve DNS
     namespace: host-interaction/network/dns/resolve
-    author:
+    authors:
       - william.ballenthin@mandiant.com
       - johnk3r
       - joakim@intezer.com

--- a/host-interaction/network/interface/get-networking-interfaces.yml
+++ b/host-interaction/network/interface/get-networking-interfaces.yml
@@ -2,7 +2,7 @@ rule:
   meta:
     name: get networking interfaces
     namespace: host-interaction/network/interface
-    author:
+    authors:
       - moritz.raabe@mandiant.com
       - joakim@intezer.com
     scope: function

--- a/host-interaction/os/hostname/get-hostname.yml
+++ b/host-interaction/os/hostname/get-hostname.yml
@@ -2,7 +2,7 @@ rule:
   meta:
     name: get hostname
     namespace: host-interaction/os/hostname
-    author:
+    authors:
       - moritz.raabe@mandiant.com
       - joakim@intezer.com
     scope: function

--- a/host-interaction/os/info/get-system-information-on-windows.yml
+++ b/host-interaction/os/info/get-system-information-on-windows.yml
@@ -2,7 +2,7 @@ rule:
   meta:
     name: get system information on Windows
     namespace: host-interaction/os/info
-    author:
+    authors:
       - moritz.raabe@mandiant.com
       - joakim@intezer.com
     scope: function

--- a/host-interaction/os/version/check-os-version.yml
+++ b/host-interaction/os/version/check-os-version.yml
@@ -2,7 +2,7 @@ rule:
   meta:
     name: check OS version
     namespace: host-interaction/os/version
-    author:
+    authors:
       - michael.hunhoff@mandiant.com
       - johnk3r
     scope: function

--- a/host-interaction/process/create/create-process-on-linux.yml
+++ b/host-interaction/process/create/create-process-on-linux.yml
@@ -2,7 +2,7 @@ rule:
   meta:
     name: create process on Linux
     namespace: host-interaction/process/create
-    author:
+    authors:
       - joakim@intezer.com
     scope: basic block
     mbc:

--- a/host-interaction/process/create/create-process-on-windows.yml
+++ b/host-interaction/process/create/create-process-on-windows.yml
@@ -2,7 +2,7 @@ rule:
   meta:
     name: create process on Windows
     namespace: host-interaction/process/create
-    author:
+    authors:
       - moritz.raabe@mandiant.com
     scope: basic block
     mbc:

--- a/host-interaction/process/inject/hijack-thread-execution.yml
+++ b/host-interaction/process/inject/hijack-thread-execution.yml
@@ -2,7 +2,7 @@ rule:
   meta:
     name: hijack thread execution
     namespace: host-interaction/process/inject
-    author:
+    authors:
       - 0x534a@mailbox.org
       - michael.hunhoff@mandiant.com
     scope: function

--- a/host-interaction/process/inject/inject-thread.yml
+++ b/host-interaction/process/inject/inject-thread.yml
@@ -2,7 +2,7 @@ rule:
   meta:
     name: inject thread
     namespace: host-interaction/process/inject
-    author:
+    authors:
       - anamaria.martinezgom@mandiant.com
       - 0x534a@mailbox.org
     scope: function

--- a/host-interaction/registry/create/set-registry-value.yml
+++ b/host-interaction/registry/create/set-registry-value.yml
@@ -2,7 +2,7 @@ rule:
   meta:
     name: set registry value
     namespace: host-interaction/registry/create
-    author:
+    authors:
       - moritz.raabe@mandiant.com
       - michael.hunhoff@mandiant.com
     scope: function

--- a/host-interaction/registry/delete/delete-registry-key.yml
+++ b/host-interaction/registry/delete/delete-registry-key.yml
@@ -2,7 +2,7 @@ rule:
   meta:
     name: delete registry key
     namespace: host-interaction/registry/delete
-    author:
+    authors:
       - moritz.raabe@mandiant.com
       - michael.hunhoff@mandiant.com
       - johnk3r

--- a/host-interaction/registry/query-or-enumerate-registry-value.yml
+++ b/host-interaction/registry/query-or-enumerate-registry-value.yml
@@ -2,7 +2,7 @@ rule:
   meta:
     name: query or enumerate registry value
     namespace: host-interaction/registry
-    author:
+    authors:
       - william.ballenthin@mandiant.com
       - michael.hunhoff@mandiant.com
     scope: function

--- a/host-interaction/service/list/enumerate-services.yml
+++ b/host-interaction/service/list/enumerate-services.yml
@@ -2,7 +2,7 @@ rule:
   meta:
     name: enumerate services
     namespace: host-interaction/service/list
-    author:
+    authors:
       - moritz.raabe@mandiant.com
       - michael.hunhoff@mandiant.com
     scope: function

--- a/host-interaction/service/run-as-service.yml
+++ b/host-interaction/service/run-as-service.yml
@@ -2,7 +2,7 @@ rule:
   meta:
     name: run as service
     namespace: host-interaction/service
-    author:
+    authors:
       - moritz.raabe@mandiant.com
       - michael.hunhoff@mandiant.com
     scope: file

--- a/host-interaction/thread/create/create-thread.yml
+++ b/host-interaction/thread/create/create-thread.yml
@@ -2,7 +2,7 @@ rule:
   meta:
     name: create thread
     namespace: host-interaction/thread/create
-    author:
+    authors:
       - moritz.raabe@mandiant.com
       - michael.hunhoff@mandiant.com
       - joakim@intezer.com

--- a/host-interaction/thread/terminate/terminate-thread.yml
+++ b/host-interaction/thread/terminate/terminate-thread.yml
@@ -2,7 +2,7 @@ rule:
   meta:
     name: terminate thread
     namespace: host-interaction/thread/terminate
-    author:
+    authors:
       - moritz.raabe@mandiant.com
       - michael.hunhoff@mandiant.com
     scope: basic block

--- a/lib/create-or-open-file.yml
+++ b/lib/create-or-open-file.yml
@@ -1,7 +1,7 @@
 rule:
   meta:
     name: create or open file
-    author:
+    authors:
       - michael.hunhoff@mandiant.com
       - joakim@intezer.com
     lib: true

--- a/linking/runtime-linking/link-function-at-runtime-on-windows.yml
+++ b/linking/runtime-linking/link-function-at-runtime-on-windows.yml
@@ -2,7 +2,7 @@ rule:
   meta:
     name: link function at runtime on Windows
     namespace: linking/runtime-linking
-    author:
+    authors:
       - moritz.raabe@mandiant.com
     scope: function
     att&ck:

--- a/linking/runtime-linking/link-many-functions-at-runtime.yml
+++ b/linking/runtime-linking/link-many-functions-at-runtime.yml
@@ -2,7 +2,7 @@ rule:
   meta:
     name: link many functions at runtime
     namespace: linking/runtime-linking
-    author:
+    authors:
       - moritz.raabe@mandiant.com
       - joakim@intezer.com
     scope: function

--- a/linking/static/openssl/linked-against-openssl.yml
+++ b/linking/static/openssl/linked-against-openssl.yml
@@ -2,7 +2,7 @@ rule:
   meta:
     name: linked against OpenSSL
     namespace: linking/static/openssl
-    author:
+    authors:
       - william.ballenthin@mandiant.com
       - michael.hunhoff@mandiant.com
     scope: file

--- a/nursery/capture-screenshot-in-go.yml
+++ b/nursery/capture-screenshot-in-go.yml
@@ -2,7 +2,7 @@ rule:
   meta:
     name: capture screenshot in Go
     namespace: collection/screenshot
-    author:
+    authors:
       - joakim@intezer.com
     description: Detects screenshot capability via WinAPI for Go files.
     scope: file

--- a/nursery/execute-syscall-instruction.yml
+++ b/nursery/execute-syscall-instruction.yml
@@ -2,7 +2,7 @@ rule:
   meta:
     name: execute syscall instruction
     namespace: anti-analysis
-    author:
+    authors:
       - "@kulinacs"
       - "@mr-tz"
     description: may be used to evade hooks or hinder analysis

--- a/nursery/get-mac-address-on-linux.yml
+++ b/nursery/get-mac-address-on-linux.yml
@@ -2,7 +2,7 @@ rule:
   meta:
     name: get MAC address on Linux
     namespace: collection/network
-    author:
+    authors:
       - joakim@intezer.com
     scope: function
     att&ck:

--- a/nursery/get-system-information-on-linux.yml
+++ b/nursery/get-system-information-on-linux.yml
@@ -2,7 +2,7 @@ rule:
   meta:
     name: get system information on Linux
     namespace: host-interaction/os/info
-    author:
+    authors:
       - joakim@intezer.com
     scope: function
     att&ck:

--- a/nursery/link-function-at-runtime-on-linux.yml
+++ b/nursery/link-function-at-runtime-on-linux.yml
@@ -2,7 +2,7 @@ rule:
   meta:
     name: link function at runtime on Linux
     namespace: linking/runtime-linking
-    author:
+    authors:
       - joakim@intezer.com
     scope: function
     att&ck:

--- a/nursery/linked-against-go-process-enumeration-library.yml
+++ b/nursery/linked-against-go-process-enumeration-library.yml
@@ -2,7 +2,7 @@ rule:
   meta:
     name: linked against Go process enumeration library
     namespace: host-interaction/process/list
-    author:
+    authors:
       - joakim@intezer.com
     description: Enumerating processes using a Go library
     scope: file

--- a/nursery/linked-against-go-registry-library.yml
+++ b/nursery/linked-against-go-registry-library.yml
@@ -2,7 +2,7 @@ rule:
   meta:
     name: linked against Go registry library
     namespace: host-interaction/registry
-    author:
+    authors:
       - joakim@intezer.com
     description: Uses a Go library for interacting with the Windows registry.
     scope: file

--- a/nursery/linked-against-go-static-asset-library.yml
+++ b/nursery/linked-against-go-static-asset-library.yml
@@ -2,7 +2,7 @@ rule:
   meta:
     name: linked against Go static asset library
     namespace: executable/resource
-    author:
+    authors:
       - joakim@intezer.com
     description: Detects if the Go file includes an static assets.
     scope: file

--- a/nursery/linked-against-go-wmi-library.yml
+++ b/nursery/linked-against-go-wmi-library.yml
@@ -2,7 +2,7 @@ rule:
   meta:
     name: linked against Go WMI library
     namespace: collection/database/wmi
-    author:
+    authors:
       - joakim@intezer.com
     description: StackExchange's WMI library is used to interact with WMI.
     scope: file

--- a/nursery/read-process-memory.yml
+++ b/nursery/read-process-memory.yml
@@ -2,7 +2,7 @@ rule:
   meta:
     name: read process memory
     namespace: host-interaction/process
-    author:
+    authors:
       - matthew.williams@mandiant.com
       - "@_re_fox"
     scope: function


### PR DESCRIPTION
https://github.com/mandiant/capa/issues/1027


so when there's a single author, we continue to use `author` but when there are multiple, then we do `authors`.
thoughts?


can easily use `authors` everywhere. see alternative in #560