### PR TITLE
Add load-dotnet-assembly.yml

### DIFF
--- a/nursery/load-dotnet-assembly.yml
+++ b/nursery/load-dotnet-assembly.yml
@@ -1,6 +1,6 @@
 rule:
   meta:
-    name: load dotnet assembly
+    name: load .NET assembly
     namespace: load-code/dotnet
     authors:
       - anushka.virgaonkar@mandiant.com

--- a/nursery/load-dotnet-assembly.yml
+++ b/nursery/load-dotnet-assembly.yml
@@ -1,0 +1,19 @@
+rule:
+  meta:
+    name: load dotnet assembly
+    namespace: load-code/dotnet
+    authors:
+      - anushka.virgaonkar@mandiant.com
+    scope: function
+    att&ck:
+      - Defense Evasion::Reflective Code Loading [T1620]
+  features:
+    - or:
+      - api: System.Reflection.Assembly::Load
+      - api: System.AppDomain::Load
+      - api: System.Reflection.Assembly::LoadFile
+      - api: System.Reflection.Assembly::LoadFrom
+      - api: System.Reflection.Assembly::LoadWithPartialName
+      - api: System.Reflection.Assembly::ReflectionOnlyLoad
+      - api: System.Reflection.Assembly::ReflectionOnlyLoadFrom
+      - api: System.Reflection.Assembly::UnsafeLoadFrom


### PR DESCRIPTION
<!--
Thank you for contributing to capa! <3

Please ensure that:
1. each rule passes thorough linting (in rules directory: `python ../scripts/lint.py --thorough -t "<your rule name>" -v .`)
2. you've uploaded each referenced example binary (optional, but greatly appreciated) to https://github.com/fireeye/capa-testfiles

Please mention the issue your PR addresses (if any):
closes #issue_number
-->

Adding a new rule that detects when a sample loads a .NET assembly.
