### PR TITLE
Create capture-screenshot-via-keybd-event.yml

### DIFF
--- a/collection/screenshot/capture-screenshot-via-keybd-event.yml
+++ b/collection/screenshot/capture-screenshot-via-keybd-event.yml
@@ -18,7 +18,7 @@ rule:
           - operand[0].number: 0x2C = VK_SNAPSHOT
           - count(api(user32.keybd_event)): 2
           - or:
-            - operand[0].number: 0x3 #KEYEVENTF_KEYUP|KEYEVENTF_EXTENDEDKEY
-            - operand[0].number: 0x2 #KEYEVENTF_KEYUP
+            - operand[0].number: 0x3 = KEYEVENTF_KEYUP|KEYEVENTF_EXTENDEDKEY
+            - operand[0].number: 0x2 = KEYEVENTF_KEYUP
       - match: read clipboard data
       - match: open clipboard

--- a/collection/screenshot/capture-screenshot-via-keybd-event.yml
+++ b/collection/screenshot/capture-screenshot-via-keybd-event.yml
@@ -1,0 +1,24 @@
+rule:
+  meta:
+    name: capture screenshot via keybd event
+    namespace: collection/screenshot
+    authors:
+      - "@_re_fox"
+    scope: function
+    att&ck:
+      - Collection::Screen Capture [T1113]
+    mbc:
+      - Collection::Screen Capture [E1113]
+    examples:
+      - 3f3bbcf8fd90bdcdcdc5494314ed4225:0x402D10
+  features:
+    - and:
+      - basic block:
+        - and:
+          - operand[0].number: 0x2C = VK_SNAPSHOT
+          - count(api(user32.keybd_event)): 2
+          - or:
+            - operand[0].number: 0x3 #KEYEVENTF_KEYUP|KEYEVENTF_EXTENDEDKEY
+            - operand[0].number: 0x2 #KEYEVENTF_KEYUP
+      - match: read clipboard data
+      - match: open clipboard


### PR DESCRIPTION
:wave: 

This is a rule that checks for a `keybd_event` of the PRINT SCREEN key (defined by vkcode `VK_SNAPSHOT`). 

In order for this technique to work, `keybd_event` requires both a key press and a secondary `KEYEVENTF_KEYUP` call.  The resulting information is then read out of the clipboard.   

I've included a sample in `capa-testfiles` via https://github.com/mandiant/capa-testfiles/pull/134