### PR TITLE
Create gather-chrome-based-browser-login-information.yml

### DIFF
--- a/collection/browser/gather-chrome-based-browser-login-information.yml
+++ b/collection/browser/gather-chrome-based-browser-login-information.yml
@@ -1,0 +1,27 @@
+rule:
+  meta:
+    name: gather chrome based browser login information
+    namespace: collection/browser
+    authors:
+      - "@_re_fox"
+    scope: function
+    att&ck:
+      - Credential Access::Credentials from Password Stores::Credentials from Web Browsers [T1555.003]
+    examples:
+      - 2fd45662e3d0ec0077ea2fa66b6378f0:0x6000039
+  features:
+    - and:
+      - or:
+        - string: /\\(Edge|Chrome|Chromium|Brave\-Browser|YandexBrowser|Kometa|Orbitum|Dragon|Torch|Amigo)\\User Data\\Default\\Login Data/
+        - string: /\\Opera Software\\Opera Stable\\Login Data/
+      - or:
+        - string: /SELECT [(date_created|username_element|password_element|origin_url|signon_realm|action_url|username_value|password_value)\s+,]+ FROM logins/i
+        - 2 or more:
+          - string: /date_created/i
+          - string: /username_element/i
+          - string: /username_value/i
+          - string: /password_element/i
+          - string: /origin_url/i
+          - string: /signon_realm/i
+          - string: /action_url/i
+          - string: /password_value/i


### PR DESCRIPTION
Simple string-based rule to look for Chrome (and Chrome-based) browser login data being referenced.   I've included a stealer in https://github.com/mandiant/capa-testfiles/pull/135 that is referenced in this rule. 

May help contribute to https://github.com/mandiant/capa-rules/issues/328.  

I leaned on regex for case-insensitivity, if there are any performance concerns I'd be happy to use regular string operators.