### PR TITLE
Graduate get-installed-programs.yml

### DIFF
--- a/host-interaction/software/get-installed-programs.yml
+++ b/host-interaction/software/get-installed-programs.yml
@@ -4,11 +4,16 @@ rule:
     namespace: host-interaction/software
     authors:
       - moritz.raabe@mandiant.com
+      - "@_re_fox"
     scope: function
     att&ck:
       - Discovery::Software Discovery [T1518]
+    examples:
+      - 7204e3efc2434012e13ca939db0d0b02:0x00412760
   features:
     - and:
       - match: create or open registry key
       - string: /SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall/i
       - characteristic: loop
+      - optional:
+        - string: "DisplayName"


### PR DESCRIPTION
:mortar_board: 

Graduate @mr-tz's rule  `get-installed-programs.yml`.  I added in additional (optional) string from the sample that is referenced in the example.  

