### PR TITLE
Create hash-data-using-jshash.yml

### DIFF
--- a/nursery/hash-data-using-jshash.yml
+++ b/nursery/hash-data-using-jshash.yml
@@ -1,0 +1,24 @@
+rule:
+  meta:
+    name: hash data using jshash
+    namespace: data-manipulation/hashing/jshash
+    authors:
+      - "@_re_fox"
+    scope: function
+    mbc:
+      - Data::Non-Cryptographic Hash [C0030]
+    references:
+      - https://www.partow.net/programming/hashfunctions/
+  features:
+    - and:
+      - number: 0x4e67c6a7
+      - instruction:
+        - description: hash << 5
+        - mnemonic: shl
+        - number: 5
+      - instruction:
+        - description: hash >> 2
+        - mnemonic: shr
+        - number: 2
+      - characteristic: nzxor
+      - characteristic: loop


### PR DESCRIPTION
Hashing algorithm JSHash.  

The primary reference implementation is:
```c
unsigned int JSHash(const char* str, unsigned int length)
{
   unsigned int hash = 1315423911;
   unsigned int i    = 0;
   for (i = 0; i < length; ++str, ++i)
   {
      hash ^= ((hash << 5) + (*str) + (hash >> 2));
   }
   return hash;
}
```
Interestingly enough this hashing function is also used `flare-ida/shellcode_hashes` under the name of `shr2Shl5XorHash32` https://github.com/mandiant/flare-ida/blob/master/shellcode_hashes/make_sc_hash_db.py#L997

I created another small testcase and disassembled 
```assembly 
┌ sym.JSHash (int64_t arg1, uint64_t arg2);
│           ; var uint64_t var_1ch @ rbp-0x1c
│           ; var int64_t var_18h @ rbp-0x18
│           ; var int64_t var_8h @ rbp-0x8
│           ; var int64_t var_4h @ rbp-0x4
│           ; arg int64_t arg1 @ rdi
│           ; arg uint64_t arg2 @ rsi
│           0x00401199      push  rbp
│           0x0040119a      mov   rbp, rsp
│           0x0040119d      mov   qword [var_18h], rdi                 ; arg1
│           0x004011a1      mov   dword [var_1ch], esi                 ; arg2
│           0x004011a4      mov   dword [var_4h], 0x4e67c6a7
│           0x004011ab      mov   dword [var_8h], 0
│           0x004011b2      mov   dword [var_8h], 0
│       ┌─< 0x004011b9      jmp   0x4011e3
│      ┌──> 0x004011bb      mov   eax, dword [var_4h]
│      ╎│   0x004011be      shl   eax, 5
│      ╎│   0x004011c1      mov   edx, eax
│      ╎│   0x004011c3      mov   rax, qword [var_18h]
│      ╎│   0x004011c7      movzx eax, byte [rax]
│      ╎│   0x004011ca      movzx eax, al
│      ╎│   0x004011cd      add   edx, eax
│      ╎│   0x004011cf      mov   eax, dword [var_4h]
│      ╎│   0x004011d2      shr   eax, 2
│      ╎│   0x004011d5      add   eax, edx
│      ╎│   0x004011d7      xor   dword [var_4h], eax
│      ╎│   0x004011da      add   qword [var_18h], 1
│      ╎│   0x004011df      add   dword [var_8h], 1
│      ╎│   ; CODE XREF from sym.JSHash @ 0x4011b9
│      ╎└─> 0x004011e3      mov   eax, dword [var_8h]
│      ╎    0x004011e6      cmp   eax, dword [var_1ch]
│      └──< 0x004011e9      jb    0x4011bb
│           0x004011eb      mov   eax, dword [var_4h]
│           0x004011ee      pop   rbp
└           0x004011ef      ret
```
And validated the rule using `capa -vv`
```
hash data using jshash
namespace   data-manipulation/hashing/jshash
author      @_re_fox
scope       function
mbc         Data::Non-Cryptographic Hash [C0030]
references  https://www.partow.net/programming/hashfunctions/
function @ 0x10004140
  and:
    number: 1315423911 @ 0x10004173
    subscope:
      and:
        mnemonic: shl @ 0x10004180
        number: 5 @ 0x10004180
    subscope:
      and:
        mnemonic: shr @ 0x10004187
        number: 2 @ 0x10004187
    characteristic: nzxor @ 0x1000418C
    characteristic: loop @ 0x10004140
```