### PR TITLE
Create hash-data-using-rshash.yml

### DIFF
--- a/nursery/hash-data-using-rshash.yml
+++ b/nursery/hash-data-using-rshash.yml
@@ -1,0 +1,16 @@
+rule:
+  meta:
+    name: hash data using rshash
+    namespace: data-manipulation/hashing/rshash
+    authors:
+      - "@_re_fox"
+    scope: function
+    mbc:
+      - Data::Non-Cryptographic Hash [C0030]
+    references:
+      - https://www.partow.net/programming/hashfunctions/
+  features:
+    - and:
+      - number: 0x5c6b7
+      - number: 0xf8c9
+      - characteristic: loop


### PR DESCRIPTION
Another hashing algorithm.  This time RSHash.  

A reference implementation is 
```c
unsigned int RSHash(const char* str, unsigned int length)
{
   unsigned int b    = 378551;
   unsigned int a    = 63689;
   unsigned int hash = 0;
   unsigned int i    = 0;
   for (i = 0; i < length; ++str, ++i)
   {
      hash = hash * a + (*str);
      a    = a * b;
   }
   return hash;
}
``` 

Due to this algorithm not utilizing shifts, the capa rule is anchoring on the 2 prime constants.  I considered adding additional restrictions using mnemonics `imul` and  `add` within a `basic block` scope, but I don't think that would add much to the rule.  

I did some cursory research on the 2 primes used (for contextual comments) but couldn't find information on why they were chosen.

Validating against a test case using `capa -vv`
```
hash data using rshash
namespace   data-manipulation/hashing/rshash
author      @_re_fox
scope       function
mbc         Data::Non-Cryptographic Hash [C0030]
references  https://www.partow.net/programming/hashfunctions/
function @ 0x401131
  and:
    number: 378551 @ 0x40113C
    number: 63689 @ 0x401143
    characteristic: loop @ 0x401131
```