### PR TITLE
Add act-as-credential-manager-dll.yml and act-as-password-filter-dll.yml

### DIFF
--- a/persistence/authentication-process/act-as-credential-manager-dll.yml
+++ b/persistence/authentication-process/act-as-credential-manager-dll.yml
@@ -1,0 +1,17 @@
+rule:
+  meta:
+    name: act as credential manager DLL
+    namespace: persistence/authentication-process
+    authors:
+      - jakub.jozwiak@mandiant.com
+    scope: file
+    att&ck:
+      - Persistence::Modify Authentication Process [T1556]
+    examples:
+      - b283415c9df06f0e53b7d452d3e5c840c5bd7a6ce734a30bae4a869a57974a0e
+  features:
+    - and:
+      - export: NPGetCaps
+      - or:
+        - export: NPLogonNotify
+        - export: NPPasswordChangeNotify

--- a/persistence/authentication-process/act-as-password-filter-dll.yml
+++ b/persistence/authentication-process/act-as-password-filter-dll.yml
@@ -1,0 +1,16 @@
+rule:
+  meta:
+    name: act as password filter DLL
+    namespace: persistence/authentication-process
+    authors:
+      - jakub.jozwiak@mandiant.com
+    scope: file
+    att&ck:
+      - Persistence::Modify Authentication Process::Password Filter DLL [T1556.002]
+    examples:
+      - 4f08636da3941f6f1e70ac2bf449b69e2ddbdc23dac58fd7eab9c5fdce6a4960
+  features:
+    - and:
+      - export: InitializeChangeNotify
+      - export: PasswordChangeNotify
+      - export: PasswordFilter


### PR DESCRIPTION
Adding two new rules for DLLs designed to act as Windows password filter or credential manager
