### PR TITLE
Additional rules to support capa-scripts.

### DIFF
--- a/c2/shell/create-reverse-shell.yml
+++ b/c2/shell/create-reverse-shell.yml
@@ -4,6 +4,7 @@ rule:
     namespace: c2/shell
     authors:
       - moritz.raabe@mandiant.com
+      - adam.storek@mandiant.com
     scope: function
     att&ck:
       - Execution::Command and Scripting Interpreter::Windows Command Shell [T1059.003]
@@ -11,6 +12,8 @@ rule:
       - Impact::Remote Access::Reverse Shell [B0022.001]
     examples:
       - C91887D861D9BD4A5872249B641BC9F9:0x401A77
+      - 2b71dd245520d9eb5f1e4c633fee61c7d83687591d9f64f9390c26dc95057c3c.aspx_
+      - 2e8c7eacd739ca3f3dc4112b41a024157035096b8d0c26ba79d8b893136391bc.aspx_
   features:
     - or:
       - and:
@@ -30,3 +33,8 @@ rule:
           - and:
             - count(api(SetHandleInformation)): 2 or more
             - number: 1 = HANDLE_FLAG_INHERIT
+      - and:
+        - match: create process on Windows
+        - or:
+          - substring: "cmd.exe"
+          - substring: "powershell.exe"

--- a/collection/database/sql/execute-sql-commands.yml
+++ b/collection/database/sql/execute-sql-commands.yml
@@ -1,0 +1,17 @@
+rule:
+  meta:
+    name: execute SQL commands
+    namespace: collection/database/sql
+    authors:
+      - adam.storek@mandiant.com
+    scope: function
+    att&ck:
+      - Collection::Data from Information Repositories [T1213]
+    examples:
+      - 6f3261eaaabf369bd928d179641b73ffd768184dfd4e00124da462a3075d4239.aspx_
+  features:
+    - and:
+      - api: "System.Data.SqlClient.SqlConnection"
+      - api: "System.Data.SqlClient.SqlConnection::Open"
+      - api: "System.Data.SqlClient.SqlCommand"
+      - api: "System.Data.SqlClient.SqlCommand::ExecuteReader"

--- a/data-manipulation/encoding/base64/decode-data-using-base64.yml
+++ b/data-manipulation/encoding/base64/decode-data-using-base64.yml
@@ -1,0 +1,14 @@
+rule:
+  meta:
+    name: decode data using Base64
+    namespace: data-manipulation/encoding/base64
+    authors:
+      - adam.storek@mandiant.com
+    scope: function
+    att&ck:
+      - Defense Evasion::Deobfuscate/Decode Files or Information [T1140]
+    examples:
+      - 10162feb5f063ea09c6a3d275f31abf0fe8a9e4e36fded0053b1f8e054da8161.aspx_
+  features:
+    - and:
+      - api: System.Convert::FromBase64String

--- a/data-manipulation/encryption/aes/decrypt-data-using-aes.yml
+++ b/data-manipulation/encryption/aes/decrypt-data-using-aes.yml
@@ -1,0 +1,23 @@
+rule:
+  meta:
+    name: decrypt data using AES
+    namespace: data-manipulation/encryption/aes
+    authors:
+      - adam.storek@mandiant.com
+    scope: function
+    att&ck:
+      - Defense Evasion::Deobfuscate/Decode Files or Information [T1140]
+    mbc:
+      - Cryptography::Decrypt Data::AES [C0031.001]
+    examples:
+      - 1f8f4054932ed1d5d055e9a92aa1e2abba49af3370506674cb1b2c70146ae81a.aspx_
+  features:
+    - or:
+      - and:
+        - api: System.Security.Cryptography.RijndaelManaged
+        - api: System.Security.Cryptography.RijndaelManaged::CreateDecryptor
+      - or:
+        - api: System.Security.Cryptography.Rijndael::Create
+        - and:
+          - api: System.Security.Cryptography.Rijndael
+          - api: System.Security.Cryptography.Rijndael::CreateDecryptor

--- a/data-manipulation/encryption/aes/encrypt-data-using-aes-via-dotnet.yml
+++ b/data-manipulation/encryption/aes/encrypt-data-using-aes-via-dotnet.yml
@@ -4,7 +4,8 @@ rule:
     namespace: data-manipulation/encryption/aes
     authors:
       - william.ballenthin@mandiant.com
-    scope: file
+      - adam.storek@mandiant.com
+    scope: function
     att&ck:
       - Defense Evasion::Obfuscated Files or Information [T1027]
     mbc:
@@ -13,6 +14,15 @@ rule:
     examples:
       - b9f5bd514485fb06da39beff051b9fdc
   features:
-    - and:
-      - class: System.Security.Cryptography.RijndaelManaged
-      - class: System.Security.Cryptography.CryptoStream
+    - or:
+      - and:
+        - api: System.Security.Cryptography.RijndaelManaged
+        - or:
+          - api: System.Security.Cryptography.CryptoStream
+          - api: System.Security.Cryptography.RijndaelManaged::CreateEncryptor
+      - and:
+        - and:
+          - or:
+            - api: System.Security.Cryptography.Rijndael
+            - api: System.Security.Cryptography.Rijndael::Create
+          - api: System.Security.Cryptography.Rijndael::CreateEncryptor

--- a/data-manipulation/hashing/md5/hash-data-with-md5.yml
+++ b/data-manipulation/hashing/md5/hash-data-with-md5.yml
@@ -32,6 +32,5 @@ rule:
           - number: 0x8003 = CALG_MD5
           - api: advapi32.CryptCreateHash
       - and:
-        - format: dotnet
         - api: System.Security.Cryptography.MD5::Create
         - api: System.Security.Cryptography.HashAlgorithm::ComputeHash

--- a/data-manipulation/hashing/sha1/hash-data-using-sha1.yml
+++ b/data-manipulation/hashing/sha1/hash-data-using-sha1.yml
@@ -4,6 +4,7 @@ rule:
     namespace: data-manipulation/hashing/sha1
     authors:
       - moritz.raabe@mandiant.com
+      - adam.storek@mandiant.com
     scope: function
     mbc:
       - Cryptography::Cryptographic Hash::SHA1 [C0029.002]
@@ -22,3 +23,7 @@ rule:
         - and:
           - number: 0x8004 = CALG_SHA1
           - api: advapi32.CryptCreateHash
+      - or:
+        - api: "System.Security.Cryptography.SHA1"
+        - api: "System.Security.Cryptography.SHA1CryptoServiceProvider"
+        - api: "System.Security.Cryptography.SHA1CryptoServiceProvider.ComputeHash"

--- a/data-manipulation/hashing/sha256/hash-data-using-sha256.yml
+++ b/data-manipulation/hashing/sha256/hash-data-using-sha256.yml
@@ -23,7 +23,6 @@ rule:
         - number: 0x1F83D9AB
         - number: 0x5BE0CD19
       - and:
-        - format: dotnet
         - or:
           - api: System.Security.Cryptography.SHA256Managed::Initialize
           - api: System.Security.Cryptography.SHA256CryptoServiceProvider::Initialize

--- a/host-interaction/process/create/create-process-on-windows.yml
+++ b/host-interaction/process/create/create-process-on-windows.yml
@@ -4,13 +4,15 @@ rule:
     namespace: host-interaction/process/create
     authors:
       - moritz.raabe@mandiant.com
-    scope: basic block
+      - adam.storek@mandiant.com
+    scope: function
     mbc:
       - Process::Create Process [C0017]
     examples:
       - 9324D1A8AE37A36AE560C37448C9705A:0x406DB0
       - Practical Malware Analysis Lab 01-04.exe_:0x4011FC
       - 692f7fd6d198e804d6af98eb9e390d61:0x6000003
+      - 03bb5cab46b406bb8613ca6e32991ab3e10b5cd759d5c7813191e9e62868ea73.aspx_
   features:
     - or:
       - api: kernel32.WinExec
@@ -29,3 +31,12 @@ rule:
       - api: ntdll.ZwCreateUserProcess
       - api: ntdll.RtlCreateUserProcess
       - api: System.Diagnostics.Process::Start
+      - and:
+        - or:
+          - and:
+            - api: System.Diagnostics.ProcessStartInfo
+            - property: System.Diagnostics.ProcessStartInfo::FileName
+          - and:
+            - api: System.Diagnostics.Process
+            - property: System.Diagnostics.Process.StartInfo::FileName
+        - api: System.Diagnostics.Process::Start

--- a/load-code/powershell/run-powershell-expression.yml
+++ b/load-code/powershell/run-powershell-expression.yml
@@ -4,11 +4,13 @@ rule:
     namespace: load-code/powershell/
     authors:
       - anamaria.martinezgom@mandiant.com
+      - adam.storek@mandiant.com
     scope: function
     att&ck:
       - Execution::Command and Scripting Interpreter::PowerShell [T1059.001]
     examples:
       - 692f7fd6d198e804d6af98eb9e390d61:0x6000004
+      - 4f6fa6a45017397c7e1c9cd5a17235ccb1ff0f5087dfa6b7384552bf507e7fe1.aspx_
   features:
     - and:
       - or:

--- a/nursery/encrypt-data-using-rsa.yml
+++ b/nursery/encrypt-data-using-rsa.yml
@@ -4,7 +4,16 @@ rule:
     namespace: data-manipulation/encryption/rsa
     authors:
       - michael.hunhoff@mandiant.com
+      - adam.storek@mandiant.com
     scope: function
+    att&ck:
+      - Defense Evasion::Obfuscated Files or Information [T1027]
+    mbc:
+      - Defense Evasion::Obfuscated Files or Information::Encryption-Standard Algorithm [E1027.m05]
+      - Cryptography::Encrypt Data::RSA [C0027.011]
+    examples:
+      - d460cae7d34c51059ef57c5aadb3de099469efbac5fffcf76d0528a511192a28.aspx_
   features:
-    - or:
+    - and:
+      - api: "System.Security.Cryptography.RSACryptoServiceProvider"
       - api: System.Security.Cryptography.RSACryptoServiceProvider::Encrypt


### PR DESCRIPTION
I noticed that the current .NET rules missed a lot of functionality/API calls that the aspx test malware includes. I therefore modified the currently available rules and created new ones to fully leverage the capa-scripts extraction capabilities.