### PR TITLE
Rule for accessing Windows directory from KUSER_SHARED_DATA

### DIFF
--- a/nursery/get-windows-directory-from-kuser_shared_data.yml
+++ b/nursery/get-windows-directory-from-kuser_shared_data.yml
@@ -11,5 +11,5 @@ rule:
     examples:
       - 7f15b1a47bbe031334e23653879e9661f4b8cde80c307548328fdd3aed87ca46:0x01019080
   features:
-    # Fixed offset of Windows directory path in KUSER_SHARED_DATA structure.
+    # Fixed offset of Windows directory path in KUSER_SHARED_DATA structure; same for 32- and 64-bit Windows.
     - number: 0x7ffe0030 = KUSER_SHARED_DATA.NtSystemRoot

--- a/nursery/get-windows-directory-from-kuser_shared_data.yml
+++ b/nursery/get-windows-directory-from-kuser_shared_data.yml
@@ -1,6 +1,6 @@
 rule:
   meta:
-    name: obtain Windows directory from KUSER_SHARED_DATA
+    name: get Windows directory from KUSER_SHARED_DATA
     namespace: host-interaction/file-system
     authors:
       - david.cannings@pwc.com
@@ -16,12 +16,12 @@ rule:
       - or:
         - mnemonic: push
         - mnemonic: mov
-      
+
       # Fixed offset of Windows directory path in KUSER_SHARED_DATA structure.
-      - number: 0x7ffe0030 = KUSER_SHARED_DATA.NtSystemRoot     
-      
+      - number: 0x7ffe0030 = KUSER_SHARED_DATA.NtSystemRoot
+
       # Typically to a string copy function or memcpy equivalent
       - mnemonic: call
-      
+
       # We could also look for a fixed length (for string / memcpy) but these vary, 
       # typically from MAX_PATH to MAX_PATH*2 with subtle variations thereof.

--- a/nursery/get-windows-directory-from-kuser_shared_data.yml
+++ b/nursery/get-windows-directory-from-kuser_shared_data.yml
@@ -12,16 +12,5 @@ rule:
       - 7f15b1a47bbe031334e23653879e9661f4b8cde80c307548328fdd3aed87ca46:0x01019080
   features:
     - and:
-      # Allow for both 32 and 64 bit calling convention.
-      - or:
-        - mnemonic: push
-        - mnemonic: mov
-
       # Fixed offset of Windows directory path in KUSER_SHARED_DATA structure.
       - number: 0x7ffe0030 = KUSER_SHARED_DATA.NtSystemRoot
-
-      # Typically to a string copy function or memcpy equivalent
-      - mnemonic: call
-
-      # We could also look for a fixed length (for string / memcpy) but these vary, 
-      # typically from MAX_PATH to MAX_PATH*2 with subtle variations thereof.

--- a/nursery/get-windows-directory-from-kuser_shared_data.yml
+++ b/nursery/get-windows-directory-from-kuser_shared_data.yml
@@ -11,6 +11,5 @@ rule:
     examples:
       - 7f15b1a47bbe031334e23653879e9661f4b8cde80c307548328fdd3aed87ca46:0x01019080
   features:
-    - and:
-      # Fixed offset of Windows directory path in KUSER_SHARED_DATA structure.
-      - number: 0x7ffe0030 = KUSER_SHARED_DATA.NtSystemRoot
+    # Fixed offset of Windows directory path in KUSER_SHARED_DATA structure.
+    - number: 0x7ffe0030 = KUSER_SHARED_DATA.NtSystemRoot

--- a/nursery/get-windows-directory-kuser-shared-data.yml
+++ b/nursery/get-windows-directory-kuser-shared-data.yml
@@ -1,0 +1,27 @@
+rule:
+  meta:
+    name: obtain Windows directory from KUSER_SHARED_DATA
+    namespace: host-interaction/file-system
+    authors:
+      - david.cannings@pwc.com
+    scope: basic block
+    references:
+      - http://www.rohitab.com/discuss/topic/42325-the-kuser-shared-data-structure/
+      - https://www.geoffchappell.com/studies/windows/km/ntoskrnl/inc/api/ntexapi_x/kuser_shared_data/index.htm
+    examples:
+      - 7f15b1a47bbe031334e23653879e9661f4b8cde80c307548328fdd3aed87ca46:0x01019080
+  features:
+    - and:
+      # Allow for both 32 and 64 bit calling convention.
+      - or:
+        - mnemonic: push
+        - mnemonic: mov
+      
+      # Fixed offset of Windows directory path in KUSER_SHARED_DATA structure.
+      - number: 0x7ffe0030 = KUSER_SHARED_DATA.NtSystemRoot     
+      
+      # Typically to a string copy function or memcpy equivalent
+      - mnemonic: call
+      
+      # We could also look for a fixed length (for string / memcpy) but these vary, 
+      # typically from MAX_PATH to MAX_PATH*2 with subtle variations thereof.


### PR DESCRIPTION
This structure is at a fixed offset in both 32 and 64 bit Windows. This rule looks for a typical function call setup to copy data from this location.

It may be possible to instead look for only the known memory address, which would catch samples that manually access memory rather than calling a function. However, this would be more prone to false positives where the same constants are used for other reasons.