### PR TITLE
Improve UAC bypass rule based on sample in the wild

### DIFF
--- a/host-interaction/uac/bypass/bypass-uac-via-token-manipulation.yml
+++ b/host-interaction/uac/bypass/bypass-uac-via-token-manipulation.yml
@@ -17,12 +17,12 @@ rule:
     - and:
       # Could expand this to include other processes that run elevated by default.
       - string: "wusa.exe"
-      
+
       # APIs to run an elevated program. Could expand this to process enumeration.
       - or:
         - api: ShellExecuteEx
         - api: ShellExecuteExW
-      
+
       # Functions designed to obtain the token
       - or:
         - api: NtOpenProcessToken
@@ -31,7 +31,7 @@ rule:
         # Some samples import the Nt* APIs dynamically, this constant is relatively
         # unique.
         - number: 0xF01FF = TOKEN_ALL_ACCESS
-      
+
       # Functions designed to (ab)use the token
       - or:
         - api: NtSetInformationToken

--- a/host-interaction/uac/bypass/bypass-uac-via-token-manipulation.yml
+++ b/host-interaction/uac/bypass/bypass-uac-via-token-manipulation.yml
@@ -4,17 +4,37 @@ rule:
     namespace: host-interaction/uac/bypass
     authors:
       - richard.cole@mandiant.com
+      - david.cannings@pwc.com
     scope: function
     att&ck:
       - Defense Evasion::Abuse Elevation Control Mechanism::Bypass User Account Control [T1548.002]
     references:
       - https://github.com/hfiref0x/UACME/blob/0a4d2bd67f4872c595f0217ef6ebdcf135186945/Source/Akagi/methods/tyranid.c#L83
+      - https://gist.github.com/dezhub/c0fee68d1e06657a45ec39365362fca7
     examples:
       - 2f43138aa75fb12ac482b486cbc98569:0x180001B48
   features:
     - and:
+      # Could expand this to include other processes that run elevated by default.
       - string: "wusa.exe"
-      - api: ShellExecuteExW
-      - api: ImpersonateLoggedOnUser
-      - api: GetStartupInfoW
-      - api: CreateProcessWithLogonW
+      
+      # APIs to run an elevated program. Could expand this to process enumeration.
+      - or:
+        - api: ShellExecuteEx
+        - api: ShellExecuteExW
+      
+      # Functions designed to obtain the token
+      - or:
+        - api: NtOpenProcessToken
+        - api: NtFilterToken
+        - api: NtDuplicateToken
+        # Some samples import the Nt* APIs dynamically, this constant is relatively
+        # unique.
+        - number: 0xF01FF = TOKEN_ALL_ACCESS
+      
+      # Functions designed to (ab)use the token
+      - or:
+        - api: NtSetInformationToken
+        - api: ImpersonateLoggedOnUser
+        - api: CreateProcessWithLogon
+        - api: CreateProcessWithLogonW


### PR DESCRIPTION
Update rule based on analysis of a sample from the wild. This sample has not been added to `examples` because it needs to be unpacked manually from memory.

The APIs have been broken into three categories:
- APIs used to run an elevated program.
- APIs for obtaining token information.
- APIs for using the token.

I removed `GetStartupInfoW`, which is not essential to the UAC bypass technique and is typically used to run the elevated process in a hidden window.

Only the string `wusa.exe` is currently included. Opened issue #615 to discuss whether this should be expanded.