### PR TITLE
Add initial UAC bypass with RPC rule

### DIFF
--- a/host-interaction/uac/bypass/bypass-uac-via-rpc.yml
+++ b/host-interaction/uac/bypass/bypass-uac-via-rpc.yml
@@ -1,0 +1,33 @@
+rule:
+  meta:
+    name: bypass UAC via RPC
+    namespace: host-interaction/uac/bypass
+    authors:
+      - david.cannings@pwc.com
+      - david@edeca.net
+    scope: function
+    att&ck:
+      - Defense Evasion::Abuse Elevation Control Mechanism::Bypass User Account Control [T1548.002]
+    references:
+      - https://googleprojectzero.blogspot.com/2019/12/
+      - https://github.com/hfiref0x/UACME/blob/master/Source/Shared/consts.h
+    examples:
+      - 6f9cb3f56d227fd57f0b75220472d744a6de894e7f74302ae39bbb164a92cdd6:0x140001D58
+  features:
+    - and:
+      - or:
+        - string: "{201ef99a-7fa0-444c-9399-19ba84f12a1a}"
+          description: IID_APPINFO
+        - string: "201ef99a-7fa0-444c-9399-19ba84f12a1a"
+          description: IID_APPINFO
+        - bytes: 9A F9 1E 20 A0 7F 4C 44 93 99 19 BA 84 F1 2A 1A = IID_APPINFO
+
+      # These APIs have been observed in samples abusing RPC for UAC bypass, and are
+      # included to guide analysts to function calls. The identifiers above are
+      # sufficient for identifying likely UAC bypass.
+      - optional:
+        - api: rpcrt4.RpcStringBindingComposeW
+        - api: rpcrt4.RpcBindingFromStringBindingW
+        - api: rpcrt4.RpcBindingSetAuthInfoExW
+        - api: rpcrt4.RpcAsyncInitializeHandle
+        - api: rpcrt4.NdrAsyncClientCall


### PR DESCRIPTION
Quick rule to detect UAC bypass using RPC.

One query on the inclusion of the byte version of the GUID. This does appear in the reference sample (at 0x140020EC0) and is referenced in the function that we expect test cases to hit. However, the reference is not direct because the code references a `MIDL_STUB_DESC` structure (at 0x140020D60) which then references the bytes in an `RpcInterfaceInformation` structure.

Advice on how to handle this appreciated - would it be worth moving the bytes to `file` scope?