### PR TITLE
Fix revert whiplash issues that caused capability loss (#629)

### DIFF
--- a/communication/http/client/check-http-status-code.yml
+++ b/communication/http/client/check-http-status-code.yml
@@ -18,7 +18,7 @@ rule:
       - optional:
         - api: atoi
         - api: wininet.HttpQueryInfo
-      - instruction:
+      - basic block:
         - and:
           - or:
             - mnemonic: cmp

--- a/data-manipulation/hashing/murmur/hash-data-using-murmur3.yml
+++ b/data-manipulation/hashing/murmur/hash-data-using-murmur3.yml
@@ -34,22 +34,20 @@ rule:
         - and:
           - description: 'hash >> 16; hash >> 13; hash >> 16'
           - count(mnemonic(shr)): 3
-          - instruction:
-            - mnemonic: shr
-            - number: 16
-          - instruction:
-            - mnemonic: shr
-            - number: 13
+          - number: 16
+          - number: 13
           - optional:
             - count(characteristic(nzxor)): 3 or more
       - and:
         # Group this two blocks under an `and` as on their own they are not
         # unique enough and would cause false positives
-        - instruction:
-          - description: k ROL r1
-          - mnemonic: rol
-          - number: 15 = r1
-        - instruction:
-          - description: hash ROL r2
-          - mnemonic: rol
-          - number: 13 = r2
+        - basic block:
+          - and:
+            - description: k ROL r1
+            - mnemonic: rol
+            - number: 15 = r1
+        - basic block:
+          - and:
+            - description: hash ROL r2
+            - mnemonic: rol
+            - number: 13 = r2

--- a/lib/calculate-modulo-256-via-x86-assembly.yml
+++ b/lib/calculate-modulo-256-via-x86-assembly.yml
@@ -4,7 +4,7 @@ rule:
     authors:
       - moritz.raabe@mandiant.com
     lib: true
-    scope: instruction
+    scope: basic block
     mbc:
       - Data::Modulo [C0058]
     examples:


### PR DESCRIPTION
When I run capa v4.0 in our automated tests, it loses a few capabilities in the report compared to v3.2.1 due to differences in the rule .yml files. I edited hash-data-using-murmur3.yml, check-http-status-code.yml, and calculate-modulo-256-via-x86-assembly.yml to match the v3 rules (kept new v4 author format) and the capabilities are restored in the report. 
