### PR TITLE
Use Serialized OIDs to identify OpenSSL

### DIFF
--- a/nursery/encrypt-data-using-openssl-dsa.yml
+++ b/nursery/encrypt-data-using-openssl-dsa.yml
@@ -1,0 +1,17 @@
+rule:
+  meta:
+    name: encrypt data using OpenSSL DSA
+    namespace: data-manipulation/encryption/dsa
+    authors:
+      - "Ana06"
+    scope: function
+    references:
+      - https://github.com/openssl/openssl/blob/fdc5043d58900663b493147298e64f11353b35fe/crypto/objects/obj_dat.h
+  features:
+    - or:
+      - bytes: 2B 0E 03 02 0D = DSA-SHA
+      - bytes: 2B 0E 03 02 0C = DSA-old
+      - bytes: 2B 0E 03 02 1B = DSA-SHA1-old
+      - bytes: 2A 86 48 CE 38 04 03 = DSA-SHA1
+      - bytes: 60 86 48 01 65 03 04 03 01 = DSA-SHA224
+      - bytes: 60 86 48 01 65 03 04 03 02 = DSA-SHA256

--- a/nursery/encrypt-data-using-openssl-ecdsa.yml
+++ b/nursery/encrypt-data-using-openssl-ecdsa.yml
@@ -1,0 +1,22 @@
+rule:
+  meta:
+    name: encrypt data using OpenSSL ECDSA
+    namespace: data-manipulation/encryption/ecdsa
+    authors:
+      - "Ana06"
+    scope: function
+    references:
+      - https://github.com/openssl/openssl/blob/fdc5043d58900663b493147298e64f11353b35fe/crypto/objects/obj_dat.h
+  features:
+    - or:
+      - bytes: 2A 86 48 CE 3D 04 02 = ECDSA with recommended
+      - bytes: 2A 86 48 CE 3D 04 03 = ECDSA with specified
+      - bytes: 2A 86 48 CE 3D 04 03 01 = ECDSA-SHA224
+      - bytes: 2A 86 48 CE 3D 04 03 02 = ECDSA-SHA256
+      - bytes: 2A 86 48 CE 3D 04 03 03 = ECDSA-SHA384
+      - bytes: 2A 86 48 CE 3D 04 03 04 = ECDSA-SHA512
+      - bytes: 60 86 48 01 65 03 04 03 09 = ECDSA-SHA3-224
+      - bytes: 60 86 48 01 65 03 04 03 0A = ECDSA-SHA3-256
+      - bytes: 60 86 48 01 65 03 04 03 0B = ECDSA-SHA3-384
+      - bytes: 60 86 48 01 65 03 04 03 0C = ECDSA-SHA3-512
+      - bytes: 2A 86 48 CE 3D 04 01 = ECDSA-SHA1

--- a/nursery/encrypt-data-using-openssl-rsa.yml
+++ b/nursery/encrypt-data-using-openssl-rsa.yml
@@ -1,0 +1,32 @@
+rule:
+  meta:
+    name: encrypt data using OpenSSL RSA
+    namespace: data-manipulation/encryption/rsa
+    authors:
+      - "Ana06"
+    scope: function
+    mbc:
+      - Cryptography::Encrypt Data::RSA [C0027.011]
+    references:
+      - https://github.com/openssl/openssl/blob/fdc5043d58900663b493147298e64f11353b35fe/crypto/objects/obj_dat.h
+  features:
+    - or:
+      - bytes: 2A 86 48 86 F7 0D 01 01 01 = RSA
+      - bytes: 2A 86 48 86 F7 0D 01 01 02 = RSA-MD2
+      - bytes: 2A 86 48 86 F7 0D 01 01 04 = RSA-MD5
+      - bytes: 2B 0E 03 02 0F = RSA-SHA
+      - bytes: 2A 86 48 86 F7 0D 01 01 05 = RSA-SHA1
+      - bytes: 2A 86 48 86 F7 0D 01 01 03 = RSA-MD4
+      - bytes: 2A 86 48 86 F7 0D 01 01 0B = RSA-SHA256
+      - bytes: 2A 86 48 86 F7 0D 01 01 0C = RSA-SHA384
+      - bytes: 2A 86 48 86 F7 0D 01 01 0D = RSA-SHA512
+      - bytes: 2A 86 48 86 F7 0D 01 01 0E = RSA-SHA224
+      - bytes: 2A 81 1C CF 55 01 83 78 = RSA-SM3
+      - bytes: 2A 86 48 86 F7 0D 01 01 0F = RSA-SHA512/224
+      - bytes: 2A 86 48 86 F7 0D 01 01 10 = RSA-SHA512/256
+      - bytes: 55 08 03 64 = RSA-MDC2
+      - bytes: 2B 24 03 03 01 02 = RSA-RIPEMD160
+      - bytes: 60 86 48 01 65 03 04 03 0D = RSA-SHA3-224
+      - bytes: 60 86 48 01 65 03 04 03 0E = RSA-SHA3-256
+      - bytes: 60 86 48 01 65 03 04 03 0F = RSA-SHA3-384
+      - bytes: 60 86 48 01 65 03 04 03 10 = RSA-SHA3-512


### PR DESCRIPTION
Use Serialized OIDs to identify RSA, DSA and ECDSA from OpenSSL.

Reference:
- https://github.com/openssl/openssl/blob/fdc5043d58900663b493147298e64f11353b35fe/crypto/objects/obj_dat.h

Identifying the bytes `2A 86 48 86 F7 0D 01 01 01` was key to identify the encryption in a Rust sample I have recently analysed. Next time capa will speed me up. 😄 I can not share the sample, so adding these rules to the nursery. 