### PR TITLE
tests: better detect rule name

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -69,7 +69,7 @@ jobs:
         cd rules/
         for changed_file in ${{ steps.files.outputs.added_modified }} ${{ steps.files.outputs.renamed }}; do
           if [[ ! $changed_file =~ .git|.md ]]; then
-            tag=$(grep 'name:' $changed_file | sed 's/^.*: //')
+            tag=$(grep '\sname:' $changed_file | sed 's/^.*: //')
             python ../scripts/lint.py --thorough -t "$tag" -v .
           fi
         done


### PR DESCRIPTION
from https://github.com/mandiant/capa-rules/pull/647


<!--
Thank you for contributing to capa! <3

Please ensure that:
1. each rule passes thorough linting (in rules directory: `python ../scripts/lint.py --thorough -t "<your rule name>" -v .`)
2. you've uploaded each referenced example binary (optional, but greatly appreciated) to https://github.com/fireeye/capa-testfiles

Please mention the issue your PR addresses (if any):
closes #issue_number
-->
