### PR TITLE
Ci/add manual workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -68,7 +68,7 @@ jobs:
       continue-on-error: true
     - name: Run thorough lint on all rule files
       # if $LINT_THOROUGH is provided in the PR body or manual run specifies it
-      if: ${{ github.event_name != 'workflow_dispatch' }} && steps.lint_thorough.outcome == 'success' || ${{ github.event_name == 'workflow_dispatch' }} && {{ github.event.inputs.thorough }}
+      if: ${{ github.event_name != 'workflow_dispatch' }} && steps.lint_thorough.outcome == 'success' || ${{ github.event_name == 'workflow_dispatch' }} && {{ github.event.inputs.thorough }} == 'true'
       run: python scripts/lint.py --thorough -v rules/
     - name: Run thorough lint on modified rule files
       # otherwise only lint modified rules thoroughly

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ on:
       thorough:
         description: 'lint --thorough'
         type: boolean
-        default: false
+        required: true
 
 # save workspaces to speed up testing
 env:
@@ -71,12 +71,9 @@ jobs:
         echo ${{ steps.lint_thorough.outcome }}
         echo ${{ github.event_name }}
         echo ${{ github.event.inputs.thorough }}
-        echo ${{ github.event_name != 'workflow_dispatch' }} && ${{ steps.lint_thorough.outcome == 'success' }}
-        echo ${{ github.event_name == 'workflow_dispatch' }} && ${{ github.event.inputs.thorough == 'true' }}
-        echo ${{ github.event_name == 'workflow_dispatch' }} && ${{ github.event.inputs.thorough }} == 'true'
     - name: Run thorough lint on all rule files
       # if $LINT_THOROUGH is provided in the PR body or manual run specifies it
-      if: ${{ github.event_name != 'workflow_dispatch' }} && ${{ steps.lint_thorough.outcome == 'success' }} || ${{ github.event_name == 'workflow_dispatch' }} && ${{ github.event.inputs.thorough }} == 'true'
+      if: github.event_name != 'workflow_dispatch' && steps.lint_thorough.outcome == 'success' || github.event_name == 'workflow_dispatch' && github.event.inputs.thorough == 'true'
       run: python scripts/lint.py --thorough -v rules/
     - name: Run thorough lint on modified rule files
       # otherwise only lint modified rules thoroughly

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -68,7 +68,7 @@ jobs:
       continue-on-error: true
     - name: Run thorough lint on all rule files
       # if $LINT_THOROUGH is provided in the PR body or manual run specifies it
-      if: ${{ github.event_name != 'workflow_dispatch' }} && steps.lint_thorough.outcome == 'success' || ${{ github.event_name == 'workflow_dispatch' }} && {{ github.event.inputs.thorough }} == 'true'
+      if: ${{ github.event_name != 'workflow_dispatch' }} && steps.lint_thorough.outcome == 'success' || ${{ github.event_name == 'workflow_dispatch' }} && {{ github.event.inputs.thorough == 'true' }}
       run: python scripts/lint.py --thorough -v rules/
     - name: Run thorough lint on modified rule files
       # otherwise only lint modified rules thoroughly

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -66,18 +66,13 @@ jobs:
       run: echo $PR_BODY | grep -qiF "$LINT_THOROUGH"
       # otherwise not finding LINT_THOROUGH would fail this step
       continue-on-error: true
-    - name: debug
-      run: |
-        echo ${{ steps.lint_thorough.outcome }}
-        echo ${{ github.event_name }}
-        echo ${{ github.event.inputs.thorough }}
     - name: Run thorough lint on all rule files
       # if $LINT_THOROUGH is provided in the PR body or manual run specifies it
       if: github.event_name != 'workflow_dispatch' && steps.lint_thorough.outcome == 'success' || github.event_name == 'workflow_dispatch' && github.event.inputs.thorough == 'true'
       run: python scripts/lint.py --thorough -v rules/
     - name: Run thorough lint on modified rule files
       # otherwise only lint modified rules thoroughly
-      if: ${{ github.event_name != 'workflow_dispatch' }} && ${{ steps.lint_thorough.outcome != 'success' }}
+      if: github.event_name != 'workflow_dispatch' && steps.lint_thorough.outcome != 'success'
       run: |
         cd rules/
         for changed_file in ${{ steps.files.outputs.added_modified }} ${{ steps.files.outputs.renamed }}; do

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,6 +50,7 @@ jobs:
       run: python scripts/lint.py rules/
     # Then run thorough lint
     - name: Get modified files
+      if: ${{ github.event_name != 'workflow_dispatch' }}
       id: files
       uses: Ana06/get-changed-files@v2.2.0
       # this Action may throw the below error, e.g. when not properly rebased
@@ -57,6 +58,7 @@ jobs:
       # Error: The head commit for this pull_request event is not ahead of the base commit.
       continue-on-error: true
     - name: Check PR text body contains LINT_THOROUGH
+      if: ${{ github.event_name != 'workflow_dispatch' }}
       id: lint_thorough
       env:
         PR_BODY: ${{ github.event.pull_request.body }}
@@ -70,7 +72,7 @@ jobs:
       run: python scripts/lint.py --thorough -v rules/
     - name: Run thorough lint on modified rule files
       # otherwise only lint modified rules thoroughly
-      if: steps.lint_thorough.outcome != 'success' || ! {{ github.event.inputs.thorough }}
+      if: steps.lint_thorough.outcome != 'success'
       run: |
         cd rules/
         for changed_file in ${{ steps.files.outputs.added_modified }} ${{ steps.files.outputs.renamed }}; do

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -71,9 +71,12 @@ jobs:
         echo ${{ steps.lint_thorough.outcome }}
         echo ${{ github.event_name }}
         echo ${{ github.event.inputs.thorough }}
+        echo ${{ github.event_name != 'workflow_dispatch' }} && steps.lint_thorough.outcome == 'success'
+        echo ${{ github.event_name == 'workflow_dispatch' }} && ${{ github.event.inputs.thorough == 'true' }}
+        echo ${{ github.event_name == 'workflow_dispatch' }} && ${{ github.event.inputs.thorough }} == 'true'
     - name: Run thorough lint on all rule files
       # if $LINT_THOROUGH is provided in the PR body or manual run specifies it
-      if: ${{ github.event_name != 'workflow_dispatch' }} && steps.lint_thorough.outcome == 'success' || ${{ github.event_name == 'workflow_dispatch' }} && ${{ github.event.inputs.thorough == 'true' }}
+      if: ${{ github.event_name != 'workflow_dispatch' }} && steps.lint_thorough.outcome == 'success' || ${{ github.event_name == 'workflow_dispatch' }} && ${{ github.event.inputs.thorough }} == 'true'
       run: python scripts/lint.py --thorough -v rules/
     - name: Run thorough lint on modified rule files
       # otherwise only lint modified rules thoroughly

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -66,9 +66,14 @@ jobs:
       run: echo $PR_BODY | grep -qiF "$LINT_THOROUGH"
       # otherwise not finding LINT_THOROUGH would fail this step
       continue-on-error: true
+    - name: debug
+      run: |
+        echo ${{ steps.lint_thorough.outcome }}
+        echo ${{ github.event_name }}
+        echo ${{ github.event.inputs.thorough }}
     - name: Run thorough lint on all rule files
       # if $LINT_THOROUGH is provided in the PR body or manual run specifies it
-      if: ${{ github.event_name != 'workflow_dispatch' }} && steps.lint_thorough.outcome == 'success' || ${{ github.event_name == 'workflow_dispatch' }} && {{ github.event.inputs.thorough == 'true' }}
+      if: ${{ github.event_name != 'workflow_dispatch' }} && steps.lint_thorough.outcome == 'success' || ${{ github.event_name == 'workflow_dispatch' }} && ${{ github.event.inputs.thorough == 'true' }}
       run: python scripts/lint.py --thorough -v rules/
     - name: Run thorough lint on modified rule files
       # otherwise only lint modified rules thoroughly

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,7 +50,7 @@ jobs:
       run: python scripts/lint.py rules/
     # Then run thorough lint
     - name: Get modified files
-      if: ${{ github.event_name != 'workflow_dispatch' }}
+      if: github.event_name != 'workflow_dispatch'
       id: files
       uses: Ana06/get-changed-files@v2.2.0
       # this Action may throw the below error, e.g. when not properly rebased
@@ -58,7 +58,7 @@ jobs:
       # Error: The head commit for this pull_request event is not ahead of the base commit.
       continue-on-error: true
     - name: Check PR text body contains LINT_THOROUGH
-      if: ${{ github.event_name != 'workflow_dispatch' }}
+      if: github.event_name != 'workflow_dispatch'
       id: lint_thorough
       env:
         PR_BODY: ${{ github.event.pull_request.body }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,6 +7,12 @@ on:
     branches: [ master, 'v[0-9]+' ]
     # trigger workflow on edited as well (opened and synchronize are default)
     types: [opened, edited, synchronize]
+  workflow_dispatch:
+    inputs:
+      thorough:
+        description: 'Lint --thorough'
+        type: boolean
+        default: false
 
 # save workspaces to speed up testing
 env:
@@ -60,11 +66,11 @@ jobs:
       continue-on-error: true
     - name: Run thorough lint on all rule files
       # if $LINT_THOROUGH is provided in the PR body
-      if: steps.lint_thorough.outcome == 'success'
+      if: steps.lint_thorough.outcome == 'success' || {{ github.event.inputs.thorough }}
       run: python scripts/lint.py --thorough -v rules/
     - name: Run thorough lint on modified rule files
       # otherwise only lint modified rules thoroughly
-      if: steps.lint_thorough.outcome != 'success'
+      if: steps.lint_thorough.outcome != 'success' || ! {{ github.event.inputs.thorough }}
       run: |
         cd rules/
         for changed_file in ${{ steps.files.outputs.added_modified }} ${{ steps.files.outputs.renamed }}; do

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
     inputs:
       thorough:
-        description: 'Lint --thorough'
+        description: 'lint --thorough'
         type: boolean
         default: false
 
@@ -67,12 +67,12 @@ jobs:
       # otherwise not finding LINT_THOROUGH would fail this step
       continue-on-error: true
     - name: Run thorough lint on all rule files
-      # if $LINT_THOROUGH is provided in the PR body
-      if: steps.lint_thorough.outcome == 'success' || {{ github.event.inputs.thorough }}
+      # if $LINT_THOROUGH is provided in the PR body or manual run specifies it
+      if: ${{ github.event_name != 'workflow_dispatch' }} && steps.lint_thorough.outcome == 'success' || ${{ github.event_name == 'workflow_dispatch' }} && {{ github.event.inputs.thorough }}
       run: python scripts/lint.py --thorough -v rules/
     - name: Run thorough lint on modified rule files
       # otherwise only lint modified rules thoroughly
-      if: steps.lint_thorough.outcome != 'success'
+      if: ${{ github.event_name != 'workflow_dispatch' }} && steps.lint_thorough.outcome != 'success'
       run: |
         cd rules/
         for changed_file in ${{ steps.files.outputs.added_modified }} ${{ steps.files.outputs.renamed }}; do

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -71,16 +71,16 @@ jobs:
         echo ${{ steps.lint_thorough.outcome }}
         echo ${{ github.event_name }}
         echo ${{ github.event.inputs.thorough }}
-        echo ${{ github.event_name != 'workflow_dispatch' }} && steps.lint_thorough.outcome == 'success'
+        echo ${{ github.event_name != 'workflow_dispatch' }} && ${{ steps.lint_thorough.outcome == 'success' }}
         echo ${{ github.event_name == 'workflow_dispatch' }} && ${{ github.event.inputs.thorough == 'true' }}
         echo ${{ github.event_name == 'workflow_dispatch' }} && ${{ github.event.inputs.thorough }} == 'true'
     - name: Run thorough lint on all rule files
       # if $LINT_THOROUGH is provided in the PR body or manual run specifies it
-      if: ${{ github.event_name != 'workflow_dispatch' }} && steps.lint_thorough.outcome == 'success' || ${{ github.event_name == 'workflow_dispatch' }} && ${{ github.event.inputs.thorough }} == 'true'
+      if: ${{ github.event_name != 'workflow_dispatch' }} && ${{ steps.lint_thorough.outcome == 'success' }} || ${{ github.event_name == 'workflow_dispatch' }} && ${{ github.event.inputs.thorough }} == 'true'
       run: python scripts/lint.py --thorough -v rules/
     - name: Run thorough lint on modified rule files
       # otherwise only lint modified rules thoroughly
-      if: ${{ github.event_name != 'workflow_dispatch' }} && steps.lint_thorough.outcome != 'success'
+      if: ${{ github.event_name != 'workflow_dispatch' }} && ${{ steps.lint_thorough.outcome != 'success' }}
       run: |
         cd rules/
         for changed_file in ${{ steps.files.outputs.added_modified }} ${{ steps.files.outputs.renamed }}; do


### PR DESCRIPTION
Allows to manually trigger CI workflow with the option to test all rules with `--thorough` argument.

Squash and merge this :)

![image](https://user-images.githubusercontent.com/17606537/210355819-c4b9144a-8e05-4130-a65d-c0fa05d80afd.png)
