### PR TITLE
Improve djb2 detection

### DIFF
--- a/data-manipulation/hashing/djb2/hash-data-using-djb2.yml
+++ b/data-manipulation/hashing/djb2/hash-data-using-djb2.yml
@@ -4,6 +4,7 @@ rule:
     namespace: data-manipulation/hashing/djb2
     authors:
       - awillia2@cisco.com
+      - still@teamt5.org
     scope: function
     mbc:
       - Data::Non-Cryptographic Hash [C0030]
@@ -18,7 +19,12 @@ rule:
         - description: hash = 5381
         - mnemonic: mov
         - number: 5381
-      - instruction:
-        - description: hash << 5
-        - mnemonic: shl
-        - number: 5
+      - or:
+        - instruction:
+          - description: hash << 5
+          - mnemonic: shl
+          - number: 5
+        - instruction:
+          - description: hash * 33
+          - mnemonic: imul
+          - number: 33

--- a/data-manipulation/hashing/djb2/hash-data-using-djb2.yml
+++ b/data-manipulation/hashing/djb2/hash-data-using-djb2.yml
@@ -26,5 +26,7 @@ rule:
           - number: 5
         - instruction:
           - description: hash * 33
-          - mnemonic: imul
+          - or:
+            - mnemonic: mul
+            - mnemonic: imul
           - number: 33

--- a/nursery/resolve-function-by-djb2-hash.yml
+++ b/nursery/resolve-function-by-djb2-hash.yml
@@ -20,4 +20,4 @@ rule:
       - number: 0xEB96C5FA = djb2(CreateFileA)
       - number: 0xEB96C610 = djb2(CreateFileW)
       - number: 0x71019921 = djb2(ReadFile)
-      - number: 0xE19E5FE = djb2(Sleep)
+      - number: 0x0E19E5FE = djb2(Sleep)

--- a/nursery/resolve-function-by-djb2-hash.yml
+++ b/nursery/resolve-function-by-djb2-hash.yml
@@ -1,0 +1,23 @@
+rule:
+  meta:
+    name: resolve function by djb2 hash
+    namespace: linking/runtime-linking
+    authors:
+      - still@teamt5.org
+    description: known import name hashes calculated using the non-cryptographic djb2 hashing algorithm
+    scope: function
+    att&ck:
+      - Defense Evasion::Obfuscated Files or Information::Indicator Removal from Tools [T1027.005]
+    mbc:
+      - Data::Non-Cryptographic Hash [C0030]
+  features:
+    - or:
+      - number: 0x5FBFF0FB = djb2(LoadLibraryA)
+      - number: 0x3870CA07 = djb2(CloseHandle)
+      - number: 0x382C0F97 = djb2(VirtualAlloc)
+      - number: 0x844FF18D = djb2(VirtualProtect)
+      - number: 0xCF31BB1F = djb2(GetProcAddress)
+      - number: 0xEB96C5FA = djb2(CreateFileA)
+      - number: 0xEB96C610 = djb2(CreateFileW)
+      - number: 0x71019921 = djb2(ReadFile)
+      - number: 0xE19E5FE = djb2(Sleep)


### PR DESCRIPTION
## Summary 

This PR improves the detection for usage of the djb2 hashing algorithm by adding the multiplication of the hash by 33 part of the instructions into the existing rule, as well as adding a new rule that detects the general usage of such hashing algorithm for function resolving.

<!--
Thank you for contributing to capa! <3

Please ensure that:
1. each rule passes thorough linting (in rules directory: `python ../scripts/lint.py --thorough -t "<your rule name>" -v .`)
2. you've uploaded each referenced example binary (optional, but greatly appreciated) to https://github.com/fireeye/capa-testfiles

Please mention the issue your PR addresses (if any):
closes #issue_number
-->
