### PR TITLE
Update encrypt-data-using-curve25519 rule

### DIFF
--- a/data-manipulation/encryption/elliptic-curve/encrypt-data-using-curve25519.yml
+++ b/data-manipulation/encryption/elliptic-curve/encrypt-data-using-curve25519.yml
@@ -4,6 +4,7 @@ rule:
     namespace: data-manipulation/encryption/elliptic-curve
     authors:
       - dimiter.andonov@mandiant.com
+    description: Targets code that enforces Curve25519's secret key restrictions. The specification states "The legitimate users are assumed to generate independent uniform random secret keys. A user can, for example, generate 32 uniform random bytes, clear bits 0, 1, 2 of the first byte, clear bit 7 of the last byte, and set bit 6 of the last byte."
     scope: basic block
     att&ck:
       - Defense Evasion::Obfuscated Files or Information [T1027]
@@ -12,17 +13,27 @@ rule:
       - 0a0882b8da225406cc838991b5f67d11:0x416f51
       - 80372de850597bd9e7e021a94f13f0a1:0x406480
       - 80372de850597bd9e7e021a94f13f0a1:0x4086f4
+      - b4a07cdd640bbaef21cd0493b4d62675:0x4098af
   features:
-    # initializes a 32-byte array with 
-    #   array[0] = 0xf8, 
-    #   array[31] = array[31] & 0x3f | 0x40
+    # Common corresponding C source code:
+    #    e[0] &= 0xf8;
+    #   e[31] &= 0x7f;
+    #   e[31] |= 0x40;
     - and:
       - instruction:
+        - description: clear bits 0, 1, and 2 of the first byte
         - mnemonic: and
         - number: 0xf8
+      - or:
+        - instruction:
+          - description: clear bit 7 of the last byte
+          - mnemonic: and
+          - number: 0x7f
+        - instruction:
+          - description: clear bits 6 and 7 of the last byte; clearing bit 6 in addition to bit 7 is fine because bit 6 is ultimately set
+          - mnemonic: and
+          - number: 0x3f
       - instruction:
-        - mnemonic: and
-        - number: 0x3f
-      - instruction:
+        - description: set bit 6 of the last byte
         - mnemonic: or
         - number: 0x40


### PR DESCRIPTION
- Added description that documents targeted code
- Added description for each instruction
- Added an additional number often used to clear only bit 7 of the last byte of the secret key