### PR TITLE
add upper limit for basic block count

### DIFF
--- a/data-manipulation/encryption/rc4/encrypt-data-using-rc4-prga.yml
+++ b/data-manipulation/encryption/rc4/encrypt-data-using-rc4-prga.yml
@@ -25,7 +25,7 @@ rule:
         - count(mnemonic(movzx)): 4 or more
       # should not call (many) functions
       - count(characteristic(calls from)): (0, 4)
-      # should not be too simple or too complex
+      # should not be too simple or too complex (50 is picked by intuition)
       - count(basic blocks): (4, 50)
       - match: contain loop
       - optional:

--- a/data-manipulation/encryption/rc4/encrypt-data-using-rc4-prga.yml
+++ b/data-manipulation/encryption/rc4/encrypt-data-using-rc4-prga.yml
@@ -25,8 +25,8 @@ rule:
         - count(mnemonic(movzx)): 4 or more
       # should not call (many) functions
       - count(characteristic(calls from)): (0, 4)
-      # should not be too simple
-      - count(basic blocks): 4 or more
+      # should not be too simple or too complex
+      - count(basic blocks): (4, 50)
       - match: contain loop
       - optional:
         - or:


### PR DESCRIPTION
closes #435

Library ID fails and RC4 PRGA matches on `___strgtold12_l`. An upped BB count prevents this.

Are there concerns on the upper limit value here?
