### PR TITLE
update rule documentation and improve .NET detection for OS gather

### DIFF
--- a/anti-analysis/anti-vm/vm-detection/check-for-windows-sandbox-via-device.yml
+++ b/anti-analysis/anti-vm/vm-detection/check-for-windows-sandbox-via-device.yml
@@ -1,6 +1,6 @@
 rule:
   meta:
-    name: check for windows sandbox via device
+    name: check for Windows sandbox via device
     namespace: anti-analysis/anti-vm/vm-detection
     authors:
       - "@_re_fox"

--- a/anti-analysis/anti-vm/vm-detection/check-for-windows-sandbox-via-dns-suffix.yml
+++ b/anti-analysis/anti-vm/vm-detection/check-for-windows-sandbox-via-dns-suffix.yml
@@ -1,6 +1,6 @@
 rule:
   meta:
-    name: check for windows sandbox via dns suffix
+    name: check for Windows sandbox via dns suffix
     namespace: anti-analysis/anti-vm/vm-detection
     authors:
       - "@_re_fox"

--- a/anti-analysis/anti-vm/vm-detection/check-for-windows-sandbox-via-genuine-state.yml
+++ b/anti-analysis/anti-vm/vm-detection/check-for-windows-sandbox-via-genuine-state.yml
@@ -1,6 +1,6 @@
 rule:
   meta:
-    name: check for windows sandbox via genuine state
+    name: check for Windows sandbox via genuine state
     namespace: anti-analysis/anti-vm/vm-detection
     authors:
       - "@_re_fox"

--- a/anti-analysis/anti-vm/vm-detection/check-for-windows-sandbox-via-process-name.yml
+++ b/anti-analysis/anti-vm/vm-detection/check-for-windows-sandbox-via-process-name.yml
@@ -1,6 +1,6 @@
 rule:
   meta:
-    name: check for windows sandbox via process name
+    name: check for Windows sandbox via process name
     namespace: anti-analysis/anti-vm/vm-detection
     authors:
       - "@_re_fox"

--- a/anti-analysis/anti-vm/vm-detection/check-for-windows-sandbox-via-registry.yml
+++ b/anti-analysis/anti-vm/vm-detection/check-for-windows-sandbox-via-registry.yml
@@ -1,6 +1,6 @@
 rule:
   meta:
-    name: check for windows sandbox via registry
+    name: check for Windows sandbox via registry
     namespace: anti-analysis/anti-vm/vm-detection
     authors:
       - "@_re_fox"

--- a/doc/format.md
+++ b/doc/format.md
@@ -396,7 +396,7 @@ Example:
     api: System.Threading.Mutex::ctor # match creation System.Threading.Mutex object
 
 ### property
-A member of a class or struct used by the logic of a program. This must include the member's class and namespace if recoverable.
+A member of a class or structure used by the logic of a program. This must include the member's class and namespace if recoverable.
 
 The parameter is a string describing the member, specificed like `namespace.class::member` or `namespace.nestednamespace.class::member`. You may also specify a `/read` accessor, if you intend a match to occur when the referenced property is read, or a `/write` accessor, if you intend a match to occur when the referenced property is written.
 

--- a/doc/format.md
+++ b/doc/format.md
@@ -47,10 +47,11 @@ We'll start at the high level structure and then dig into the logic structures a
   - [features block](#features-block)
 - [extracted features](#extracted-features)
   - [characteristic](#characteristic)
-  - [instruction features](#function-features)
+  - [instruction features](#instruction-features)
     - [namespace](#namespace)
     - [class](#class)
     - [api](#api)
+    - [property](#property)
     - [number](#number)
     - [string and substring](#string-and-substring)
     - [bytes](#bytes)
@@ -337,6 +338,7 @@ The following features are relevant at this scope and above:
   - [namespace](#namespace)
   - [class](#class)
   - [api](#api)
+  - [property](#property)
   - [number](#number)
   - [string and substring](#string-and-substring)
   - [bytes](#bytes)
@@ -382,6 +384,8 @@ The parameter is a string describing the function name, specified like  `functio
 
 Windows API functions that take string arguments come in two API versions. For example, `CreateProcessA` takes ANSI strings and `CreateProcessW` takes Unicode strings. capa extracts these API features both with and without the suffix character `A` or `W`. That means you can write a rule to match on both APIs using the base name. If you want to match a specific API version, you can include the suffix.
 
+.NET classes and structures implement constructor (`.ctor`) and static constructor (`.cctor`) methods. capa extracts these constructor methods as `namespace.class::ctor` and `namespace.class::cctor`, respectively.
+
 Example:
 
     api: kernel32.CreateFile  # matches both Ansi (CreateFileA) and Unicode (CreateFileW) versions
@@ -389,6 +393,17 @@ Example:
     api: GetEnvironmentVariableW  # only matches on Unicode version
     api: System.IO.File::Delete
     api: System.Net.WebResponse::GetResponseStream
+    api: System.Threading.Mutex::ctor # match creation System.Threading.Mutex object
+
+### property
+A member of a class or struct used by the logic of a program. This must include the member's class and namespace if recoverable.
+
+The paramerter is a string describing the member, specificed like `namespace.class::member` or `namespace.nestednamespace.class::member`. You may also specify a `/read` accessor, if you intend a match to occur when the referenced property is read, or a `/write` accessor, if you intend a match to occur when the referenced property is written.
+
+Example:
+
+    property/read: System.Environment::OSVersion
+    property/write: System.Net.WebRequest::Proxy
 
 ### number
 A number used by the logic of the program.

--- a/host-interaction/file-system/files/list/enumerate-files-on-windows.yml
+++ b/host-interaction/file-system/files/list/enumerate-files-on-windows.yml
@@ -1,6 +1,6 @@
 rule:
   meta:
-    name: enumerate files on windows
+    name: enumerate files on Windows
     namespace: host-interaction/file-system/files/list
     authors:
       - moritz.raabe@mandiant.com

--- a/host-interaction/file-system/files/list/enumerate-files-recursively.yml
+++ b/host-interaction/file-system/files/list/enumerate-files-recursively.yml
@@ -15,5 +15,5 @@ rule:
   features:
     - and:
       - or:
-        - match: enumerate files on windows
+        - match: enumerate files on Windows
       - characteristic: recursive call

--- a/nursery/check-for-windows-sandbox-via-mutex.yml
+++ b/nursery/check-for-windows-sandbox-via-mutex.yml
@@ -1,6 +1,6 @@
 rule:
   meta:
-    name: check for windows sandbox via mutex
+    name: check for Windows sandbox via mutex
     namespace: anti-analysis/anti-vm/vm-detection
     authors:
       - "@_re_fox"

--- a/nursery/get-os-version-in-dotnet.yml
+++ b/nursery/get-os-version-in-dotnet.yml
@@ -13,3 +13,4 @@ rule:
       - property/read: System.Environment::Is64BitOperatingSystem
       - property/read: System.OperatingSystem::Version
       - property/read: Microsoft.VisualBasic.Devices.ComputerInfo::OSFullName
+      - property/read: System.Runtime.InteropServices.RuntimeInformation::OSDescription


### PR DESCRIPTION
- Updates documentation to include `property` and .NET constructor features (closes #722)
- Fixes capitalization of some rules
- Adds new API to detect OS read in .NET