### PR TITLE
adding new rule for destroying capability of adding software breakpoints

### DIFF
--- a/anti-analysis/anti-debugging/destroy-software-breakpoint-capability.yml
+++ b/anti-analysis/anti-debugging/destroy-software-breakpoint-capability.yml
@@ -1,0 +1,17 @@
+rule:
+  meta:
+    name: destroy software breakpoint capability
+    namespace: anti-analysis/anti-debugging
+    authors:
+      - echernofsky@google.com
+    scope: function
+    references:
+      - https://www.microsoft.com/en-us/security/blog/2018/03/01/finfisher-exposed-a-researchers-tale-of-defeating-traps-tricks-and-complex-virtual-machines/
+      - https://anti-debug.checkpoint.com/techniques/assembly.html
+      - https://www.mandiant.com/sites/default/files/2021-10/09-evil.pdf
+    examples:
+      - al-khaser_x86.exe_:0x431020
+  features:
+    - and:
+      - api: VirtualProtect
+      - api: DbgBreakPoint    # This API is used as an argument to VirtualProtect to allow modification.

--- a/nursery/destroy-software-breakpoint-capability.yml
+++ b/nursery/destroy-software-breakpoint-capability.yml
@@ -9,8 +9,8 @@ rule:
       - https://www.microsoft.com/en-us/security/blog/2018/03/01/finfisher-exposed-a-researchers-tale-of-defeating-traps-tricks-and-complex-virtual-machines/
       - https://anti-debug.checkpoint.com/techniques/assembly.html
       - https://www.mandiant.com/sites/default/files/2021-10/09-evil.pdf
-    examples:
-      - al-khaser_x86.exe_:0x431020
+    # examples:
+    #   - al-khaser_x86.exe_:0x431020
   features:
     - and:
       - api: VirtualProtect


### PR DESCRIPTION
`VirtualProtectEx(CurProc, &DbgBreakPoint, 1, PAGE_RWX, &oldProtect);`
`DbgBreakPoint[0] = <some new value here, usually NOP or RET>`