### PR TITLE
add new rule to detect .NET files w/ uncommon TLS section

### DIFF
--- a/nursery/contain-a-thread-local-storage-tls-section-in-dotnet.yml
+++ b/nursery/contain-a-thread-local-storage-tls-section-in-dotnet.yml
@@ -1,0 +1,14 @@
+rule:
+  meta:
+    name: contain a thread local storage (.tls) section in .NET
+    namespace: executable/pe/section/tls
+    authors:
+      - michael.hunhoff@mandiant.com
+    description: .NET file contains uncommon TLS section
+    scope: file
+    references:
+      - https://washi.dev/blog/posts/entry-points/
+  features:
+    - and:
+      - match: contain a thread local storage (.tls) section
+      - format: dotnet


### PR DESCRIPTION
This rule aims to detect .NET files containing a `TLS` section (see #725). A quick VT hunt using `tag:assembly section:tls` matched less than 10 samples so it appears the presence of a `TLS` section in .NET files is pretty uncommon. The referenced blog demonstrates how a `TLS` section can be injected into a `.NET` file to execute potentially malicious code so IMO it's worth noting this to capa users.