### PR TITLE
Update reference-absolute-stream-path-on-windows.yml

### DIFF
--- a/host-interaction/file-system/reference-absolute-stream-path-on-windows.yml
+++ b/host-interaction/file-system/reference-absolute-stream-path-on-windows.yml
@@ -12,21 +12,20 @@ rule:
       - 51828683DC26BFABD3994494099AE97D:0x11A9
   features:
     - and:
-      - string: /^(..\?\\)?([\w]\:|\\)(\\+((?![\<\>\"\/\|\*\?\:\\])[\x20-\x5B\x5D-\x7E])+)+(\:\$?([a-zA-Z0-9_]+))?/
-        # ^(..\?\\)? -> Check for path starting with "\\?\"
-        # ([\w]\:|\\) -> Check for absolute path beginning
-        # (\\+((?![\<\>\"\/\|\*\?\:\\])[\x20-\x5B\x5D-\x7E])+)+ -> Check for valid path and filename
-        #   \\+ -> Check for at least one backslash path separator
+      - string: /^(\\\\\\\\\?\\)?([\w]\:|\\\\)(\\\\((?![\<\>\"\/\|\*\?\:\\])[\x20-\x5B\x5D-\x7E])+)+\:\$?[a-zA-Z0-9_]+/
+        # ^(\\\\\\\\\?\\)? -> Check for path starting with "\\?\"
+        # ([\w]\:|\\\\) -> Check for absolute path beginning
+        # (\\\\((?![\<\>\"\/\|\*\?\:\\])[\x20-\x5B\x5D-\x7E])+)+ -> Check for valid path and filename
+        #   \\\\ -> Check for double backslash path separator
         #   (?![\<\>\"\/\|\*\?\:\\]) -> path component must not start with <, >, ", ...
         #   [\x20-\x5B\x5D-\x7E] -> path component must be printable ASCII, except backslash path separator
         # : -> Check for start of stream filename
-        # \$?([a-zA-Z0-9_]+))? -> Check for valid stream filename
+        # \$?[a-zA-Z0-9_]+ -> Check for valid stream filename
         ### Example Matches:
-        ### \\\\server\share\\file:stream
-        ### \\\\server\share\dir.ext\\file.ext:stream 
-        ### \\\\server\share\dir.ext\\file.tar.gz:stream
-        ### \\\\server\share\dir.ext\\file:stream.tar.gz
-        ### \\\\server\share\dir\\file.ext:stream.ext
-        ### \\\\?\C:\dir1\dir2\\file:stream
-        ### C:\dir\\file:stream.ext
-        ### C:\dir\\file:}{+,.';[]-=-0987654321`~!@#$%^&()_+-.ext
+        ### \\\\server\\share\\file:stream
+        ### \\\\server\\share\\dir.ext\\file.ext:stream 
+        ### \\\\server\\share\\dir.ext\\file.tar.gz:stream
+        ### \\\\server\\share\\dir.ext\\file:stream.tar.gz
+        ### \\\\server\\share\dir\\file.ext:stream.ext
+        ### \\\\?\C:\\dir1\\dir2\\file:stream
+        ### C:\\dir\\file:stream.ext

--- a/host-interaction/file-system/reference-absolute-stream-path-on-windows.yml
+++ b/host-interaction/file-system/reference-absolute-stream-path-on-windows.yml
@@ -12,11 +12,11 @@ rule:
       - 51828683DC26BFABD3994494099AE97D:0x11A9
   features:
     - and:
-      - string: /^(\\\\\\\\\?\\)?([\w]\:|\\\\)(\\\\((?![\<\>\"\/\|\*\?\:\\])[\x20-\x5B\x5D-\x7E])+)+\:\$?[a-zA-Z0-9_]+/
-        # ^(\\\\\\\\\?\\)? -> Check for path starting with "\\?\"
-        # ([\w]\:|\\\\) -> Check for absolute path beginning
-        # (\\\\((?![\<\>\"\/\|\*\?\:\\])[\x20-\x5B\x5D-\x7E])+)+ -> Check for valid path and filename
-        #   \\\\ -> Check for double backslash path separator
+      - string: /^(\\\\\?\\)?([\w]\:|\\)(\\((?![\<\>\"\/\|\*\?\:\\])[\x20-\x5B\x5D-\x7E])+)+\:\$?[a-zA-Z0-9_]+/
+        # ^(\\\\\?\\)? -> Check for path starting with "\\?\"
+        # ([\w]\:|\\) -> Check for absolute path beginning
+        # (\\((?![\<\>\"\/\|\*\?\:\\])[\x20-\x5B\x5D-\x7E])+)+ -> Check for valid path and filename
+        #   \\ -> Check for double backslash path separator
         #   (?![\<\>\"\/\|\*\?\:\\]) -> path component must not start with <, >, ", ...
         #   [\x20-\x5B\x5D-\x7E] -> path component must be printable ASCII, except backslash path separator
         # : -> Check for start of stream filename
@@ -24,8 +24,8 @@ rule:
         ### Example Matches:
         ### \\\\server\\share\\file:stream
         ### \\\\server\\share\\dir.ext\\file.ext:stream 
-        ### \\\\server\\share\\dir.ext\\file.tar.gz:stream
-        ### \\\\server\\share\\dir.ext\\file:stream.tar.gz
-        ### \\\\server\\share\dir\\file.ext:stream.ext
-        ### \\\\?\C:\\dir1\\dir2\\file:stream
+        ### \\\\server\\share\\dir\\file.ext:stream.ext
+        ### \\\\?\\C:\\dir1\\dir2\\file:stream
         ### C:\\dir\\file:stream.ext
+        ### d:\\myfile.dat:stream1
+        ### c:\\string:myfile.dat


### PR DESCRIPTION
<!--
Thank you for contributing to capa! <3

Please ensure that:
1. each rule passes thorough linting (in rules directory: `python ../scripts/lint.py --thorough -t "<your rule name>" -v .`)
2. you've uploaded each referenced example binary (optional, but greatly appreciated) to https://github.com/fireeye/capa-testfiles

Please mention the issue your PR addresses (if any):
closes #issue_number
-->

Resolves FP cases where `C:\\windows\\system32\\kerne132.dll` and `\\\\\\\\\\\\\\server\\share\\file:stream` are detected. Updated comments and regex to reflect this. Made additional modifications to regex for performance enhancement.
