### PR TITLE
Added rule to detect minifilter driver enumeration

### DIFF
--- a/anti-analysis/anti-av/enumerate-minifilter-drivers.yml
+++ b/anti-analysis/anti-av/enumerate-minifilter-drivers.yml
@@ -1,0 +1,18 @@
+rule:
+  meta:
+    name: enumerate minifilter drivers
+    namespace: anti-analysis/anti-av
+    authors:
+      - aseel.kayal@mandiant.com
+    scope: function
+    mbc:
+      - Defense Evasion::Disable or Evade Security Tools [F0004]
+    references:
+      - https://posts.specterops.io/mimidrv-in-depth-4d273d19e148
+      - https://learn.microsoft.com/en-us/windows-hardware/drivers/ifs/filter-manager-concepts
+    examples:
+      - 3E528207CA374123F63789195A4AEDDE:0x12F49
+  features:
+    - and:
+      - api: fltmgr.FltEnumerateFilters
+      - api: fltmgr.FltGetFilterInformation


### PR DESCRIPTION
Added CAPA rules to detect minifilter driver enumeration, which can assist in detecting installed AV engines on a compromised system.


<!--
Thank you for contributing to capa! <3

Please ensure that:
1. each rule passes thorough linting (in rules directory: `python ../scripts/lint.py --thorough -t "<your rule name>" -v .`)
2. you've uploaded each referenced example binary (optional, but greatly appreciated) to https://github.com/fireeye/capa-testfiles

Please mention the issue your PR addresses (if any):
closes #issue_number
-->
