### PR TITLE
Create enumerate-minifilter-drivers.yml

### DIFF
--- a/host-interaction/filter/enumerate-minifilter-drivers.yml
+++ b/host-interaction/filter/enumerate-minifilter-drivers.yml
@@ -1,0 +1,16 @@
+rule:
+  meta:
+    name: enumerate minifilter drivers
+    namespace: host-interaction/filter
+    authors:
+      - aseel.kayal@mandiant.com
+    scope: function
+    references:
+      - https://posts.specterops.io/mimidrv-in-depth-4d273d19e148
+      - https://learn.microsoft.com/en-us/windows-hardware/drivers/ifs/filter-manager-concepts
+    examples:
+      - 3E528207CA374123F63789195A4AEDDE:0x12F49
+  features:
+    - and:
+      - api: fltmgr.FltEnumerateFilters
+      - api: fltmgr.FltGetFilterInformation


### PR DESCRIPTION
Moved rule to enumerate minifilter drivers from anti-analysis/anti-av to host-interaction/filter, added sample to test samples repository


<!--
Thank you for contributing to capa! <3

Please ensure that:
1. each rule passes thorough linting (in rules directory: `python ../scripts/lint.py --thorough -t "<your rule name>" -v .`)
2. you've uploaded each referenced example binary (optional, but greatly appreciated) to https://github.com/fireeye/capa-testfiles

Please mention the issue your PR addresses (if any):
closes #issue_number
-->
