### PR TITLE
revert missing MBC tag so linter succeeds again

### DIFF
--- a/host-interaction/process/inject/inject-apc.yml
+++ b/host-interaction/process/inject/inject-apc.yml
@@ -7,8 +7,6 @@ rule:
     scope: function
     att&ck:
       - Defense Evasion::Process Injection::Asynchronous Procedure Call [T1055.004]
-    mbc:
-      - Defense Evasion::Process Injection::Asynchronous Procedure Call [E1055.004]
     examples:
       - al-khaser_x64.exe_:0x140019348
   features:


### PR DESCRIPTION
E1055.004 cannot be validated at the moment