### PR TITLE
add `send SMS on Android`

### DIFF
--- a/nursery/send-sms-on-android.yml
+++ b/nursery/send-sms-on-android.yml
@@ -1,0 +1,24 @@
+rule:
+  meta:
+    name: send SMS on Android
+    namespace: communication/sms
+    authors:
+      - "@mr-tz"
+    scope: function
+    # att&ck:
+    #   - Mobile::SMS Control [T1582]
+  features:
+    - and:
+      - os: android
+      # ... = (*env)->FindClass(env, "android/telephony/SmsManager");
+      - string: "android/telephony/SmsManager"
+      - optional:
+        - or:
+          - and:
+            - arch: i386
+            - offset: 0x30 = (*env)->FindClass
+          - and:
+            - arch: amd64
+            - offset: 0x1C = (*env)->FindClass
+      # ... = (*env)->GetMethodID(env, ..., "sendTextMessage" ...);
+      - string: "sendTextMessage"


### PR DESCRIPTION
First rule for Android (native code called via JNI), here from a private 64-bit .so file. Very similar code is also referenced in https://stackoverflow.com/questions/30175062/jni-callvoidmethod-leads-to-fatal-signal-6-and-invalid-indirect-reference.

Question: do we want to mix mobile with desktop for namespaces and ATT&CK?
