### PR TITLE
Add `dynamic: unspecified` to static-only rules

### DIFF
--- a/anti-analysis/anti-debugging/debugger-detection/check-for-hardware-breakpoints.yml
+++ b/anti-analysis/anti-debugging/debugger-detection/check-for-hardware-breakpoints.yml
@@ -6,7 +6,7 @@ rule:
       - michael.hunhoff@mandiant.com
     scopes:
       static: function
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     mbc:
       - Anti-Behavioral Analysis::Debugger Detection::Hardware Breakpoints [B0001.005]
     references:

--- a/anti-analysis/anti-debugging/debugger-detection/check-for-hardware-breakpoints.yml
+++ b/anti-analysis/anti-debugging/debugger-detection/check-for-hardware-breakpoints.yml
@@ -6,6 +6,7 @@ rule:
       - michael.hunhoff@mandiant.com
     scopes:
       static: function
+      dynamic: unspecified
     mbc:
       - Anti-Behavioral Analysis::Debugger Detection::Hardware Breakpoints [B0001.005]
     references:

--- a/anti-analysis/anti-debugging/debugger-detection/check-for-kernel-debugger-via-shared-user-data-structure.yml
+++ b/anti-analysis/anti-debugging/debugger-detection/check-for-kernel-debugger-via-shared-user-data-structure.yml
@@ -6,6 +6,7 @@ rule:
       - michael.hunhoff@mandiant.com
     scopes:
       static: function
+      dynamic: unspecified
     mbc:
       - Anti-Behavioral Analysis::Debugger Detection [B0001]
     references:

--- a/anti-analysis/anti-debugging/debugger-detection/check-for-kernel-debugger-via-shared-user-data-structure.yml
+++ b/anti-analysis/anti-debugging/debugger-detection/check-for-kernel-debugger-via-shared-user-data-structure.yml
@@ -6,7 +6,7 @@ rule:
       - michael.hunhoff@mandiant.com
     scopes:
       static: function
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     mbc:
       - Anti-Behavioral Analysis::Debugger Detection [B0001]
     references:

--- a/anti-analysis/anti-debugging/debugger-detection/check-for-peb-beingdebugged-flag.yml
+++ b/anti-analysis/anti-debugging/debugger-detection/check-for-peb-beingdebugged-flag.yml
@@ -6,6 +6,7 @@ rule:
       - moritz.raabe@mandiant.com
     scopes:
       static: basic block
+      dynamic: unspecified
     mbc:
       - Anti-Behavioral Analysis::Debugger Detection::Process Environment Block BeingDebugged [B0001.035]
     references:

--- a/anti-analysis/anti-debugging/debugger-detection/check-for-peb-beingdebugged-flag.yml
+++ b/anti-analysis/anti-debugging/debugger-detection/check-for-peb-beingdebugged-flag.yml
@@ -6,7 +6,7 @@ rule:
       - moritz.raabe@mandiant.com
     scopes:
       static: basic block
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     mbc:
       - Anti-Behavioral Analysis::Debugger Detection::Process Environment Block BeingDebugged [B0001.035]
     references:

--- a/anti-analysis/anti-debugging/debugger-detection/check-for-peb-ntglobalflag-flag.yml
+++ b/anti-analysis/anti-debugging/debugger-detection/check-for-peb-ntglobalflag-flag.yml
@@ -6,6 +6,7 @@ rule:
       - moritz.raabe@mandiant.com
     scopes:
       static: function
+      dynamic: unspecified
     mbc:
       - Anti-Behavioral Analysis::Debugger Detection::Process Environment Block NtGlobalFlag [B0001.036]
     references:

--- a/anti-analysis/anti-debugging/debugger-detection/check-for-peb-ntglobalflag-flag.yml
+++ b/anti-analysis/anti-debugging/debugger-detection/check-for-peb-ntglobalflag-flag.yml
@@ -6,7 +6,7 @@ rule:
       - moritz.raabe@mandiant.com
     scopes:
       static: function
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     mbc:
       - Anti-Behavioral Analysis::Debugger Detection::Process Environment Block NtGlobalFlag [B0001.036]
     references:

--- a/anti-analysis/anti-debugging/debugger-detection/check-for-software-breakpoints.yml
+++ b/anti-analysis/anti-debugging/debugger-detection/check-for-software-breakpoints.yml
@@ -6,6 +6,7 @@ rule:
       - michael.hunhoff@mandiant.com
     scopes:
       static: function
+      dynamic: unspecified
     mbc:
       - Anti-Behavioral Analysis::Debugger Detection::Software Breakpoints [B0001.025]
     references:

--- a/anti-analysis/anti-debugging/debugger-detection/check-for-software-breakpoints.yml
+++ b/anti-analysis/anti-debugging/debugger-detection/check-for-software-breakpoints.yml
@@ -6,7 +6,7 @@ rule:
       - michael.hunhoff@mandiant.com
     scopes:
       static: function
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     mbc:
       - Anti-Behavioral Analysis::Debugger Detection::Software Breakpoints [B0001.025]
     references:

--- a/anti-analysis/anti-debugging/debugger-detection/check-for-time-delay-via-gettickcount.yml
+++ b/anti-analysis/anti-debugging/debugger-detection/check-for-time-delay-via-gettickcount.yml
@@ -6,6 +6,7 @@ rule:
       - michael.hunhoff@mandiant.com
     scopes:
       static: function
+      dynamic: unspecified
     mbc:
       - Anti-Behavioral Analysis::Debugger Detection::Timing/Delay Check GetTickCount [B0001.032]
     examples:

--- a/anti-analysis/anti-debugging/debugger-detection/check-for-time-delay-via-gettickcount.yml
+++ b/anti-analysis/anti-debugging/debugger-detection/check-for-time-delay-via-gettickcount.yml
@@ -6,7 +6,7 @@ rule:
       - michael.hunhoff@mandiant.com
     scopes:
       static: function
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     mbc:
       - Anti-Behavioral Analysis::Debugger Detection::Timing/Delay Check GetTickCount [B0001.032]
     examples:

--- a/anti-analysis/anti-debugging/debugger-detection/check-for-trap-flag-exception.yml
+++ b/anti-analysis/anti-debugging/debugger-detection/check-for-trap-flag-exception.yml
@@ -6,6 +6,7 @@ rule:
       - michael.hunhoff@mandiant.com
     scopes:
       static: basic block
+      dynamic: unspecified
     mbc:
       - Anti-Behavioral Analysis::Debugger Detection [B0001]
     references:

--- a/anti-analysis/anti-debugging/debugger-detection/check-for-trap-flag-exception.yml
+++ b/anti-analysis/anti-debugging/debugger-detection/check-for-trap-flag-exception.yml
@@ -6,7 +6,7 @@ rule:
       - michael.hunhoff@mandiant.com
     scopes:
       static: basic block
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     mbc:
       - Anti-Behavioral Analysis::Debugger Detection [B0001]
     references:

--- a/anti-analysis/anti-debugging/debugger-detection/execute-anti-debugging-instructions.yml
+++ b/anti-analysis/anti-debugging/debugger-detection/execute-anti-debugging-instructions.yml
@@ -6,6 +6,7 @@ rule:
       - moritz.raabe@mandiant.com
     scopes:
       static: function
+      dynamic: unspecified
     mbc:
       - Anti-Behavioral Analysis::Debugger Detection::Anti-debugging Instructions [B0001.034]
     examples:

--- a/anti-analysis/anti-debugging/debugger-detection/execute-anti-debugging-instructions.yml
+++ b/anti-analysis/anti-debugging/debugger-detection/execute-anti-debugging-instructions.yml
@@ -6,7 +6,7 @@ rule:
       - moritz.raabe@mandiant.com
     scopes:
       static: function
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     mbc:
       - Anti-Behavioral Analysis::Debugger Detection::Anti-debugging Instructions [B0001.034]
     examples:

--- a/anti-analysis/anti-disasm/64-bit-execution-via-heavens-gate.yml
+++ b/anti-analysis/anti-disasm/64-bit-execution-via-heavens-gate.yml
@@ -7,6 +7,7 @@ rule:
     description: Looks for instructions related to executing 64-bit code from a 32-bit process (Heaven's Gate)
     scopes:
       static: function
+      dynamic: unspecified
     mbc:
       - Defense Evasion::Disable or Evade Security Tools::Heavens Gate [F0004.008]
     references:

--- a/anti-analysis/anti-disasm/64-bit-execution-via-heavens-gate.yml
+++ b/anti-analysis/anti-disasm/64-bit-execution-via-heavens-gate.yml
@@ -7,7 +7,7 @@ rule:
     description: Looks for instructions related to executing 64-bit code from a 32-bit process (Heaven's Gate)
     scopes:
       static: function
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     mbc:
       - Defense Evasion::Disable or Evade Security Tools::Heavens Gate [F0004.008]
     references:

--- a/anti-analysis/anti-forensic/patch-process-command-line.yml
+++ b/anti-analysis/anti-forensic/patch-process-command-line.yml
@@ -7,7 +7,7 @@ rule:
       - "@_re_fox"
     scopes:
       static: function
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     att&ck:
       - Defense Evasion::Process Injection [T1055]
     mbc:

--- a/anti-analysis/anti-forensic/patch-process-command-line.yml
+++ b/anti-analysis/anti-forensic/patch-process-command-line.yml
@@ -7,6 +7,7 @@ rule:
       - "@_re_fox"
     scopes:
       static: function
+      dynamic: unspecified
     att&ck:
       - Defense Evasion::Process Injection [T1055]
     mbc:

--- a/anti-analysis/anti-forensic/self-deletion/self-delete.yml
+++ b/anti-analysis/anti-forensic/self-deletion/self-delete.yml
@@ -7,6 +7,7 @@ rule:
       - "@mr-tz"
     scopes:
       static: function
+      dynamic: unspecified
     att&ck:
       - Defense Evasion::Indicator Removal::File Deletion [T1070.004]
     mbc:

--- a/anti-analysis/anti-forensic/self-deletion/self-delete.yml
+++ b/anti-analysis/anti-forensic/self-deletion/self-delete.yml
@@ -7,7 +7,7 @@ rule:
       - "@mr-tz"
     scopes:
       static: function
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     att&ck:
       - Defense Evasion::Indicator Removal::File Deletion [T1070.004]
     mbc:

--- a/anti-analysis/anti-vm/vm-detection/check-for-foreground-window-switch.yml
+++ b/anti-analysis/anti-vm/vm-detection/check-for-foreground-window-switch.yml
@@ -7,6 +7,7 @@ rule:
     description: Detect usage of GetForegroundWindow and Sleep APIs to check if there is any foreground window switch. Typically, sandboxes do not switch the foreground window like a user would in a normal environment.
     scopes:
       static: function
+      dynamic: unspecified
     att&ck:
       - Defense Evasion::Virtualization/Sandbox Evasion::User Activity Based Checks [T1497.002]
     references:

--- a/anti-analysis/anti-vm/vm-detection/check-for-foreground-window-switch.yml
+++ b/anti-analysis/anti-vm/vm-detection/check-for-foreground-window-switch.yml
@@ -7,7 +7,7 @@ rule:
     description: Detect usage of GetForegroundWindow and Sleep APIs to check if there is any foreground window switch. Typically, sandboxes do not switch the foreground window like a user would in a normal environment.
     scopes:
       static: function
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     att&ck:
       - Defense Evasion::Virtualization/Sandbox Evasion::User Activity Based Checks [T1497.002]
     references:

--- a/anti-analysis/anti-vm/vm-detection/check-for-windows-sandbox-via-dns-suffix.yml
+++ b/anti-analysis/anti-vm/vm-detection/check-for-windows-sandbox-via-dns-suffix.yml
@@ -6,7 +6,7 @@ rule:
       - "@_re_fox"
     scopes:
       static: function
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     att&ck:
       - Defense Evasion::Virtualization/Sandbox Evasion::System Checks [T1497.001]
     mbc:

--- a/anti-analysis/anti-vm/vm-detection/check-for-windows-sandbox-via-dns-suffix.yml
+++ b/anti-analysis/anti-vm/vm-detection/check-for-windows-sandbox-via-dns-suffix.yml
@@ -6,6 +6,7 @@ rule:
       - "@_re_fox"
     scopes:
       static: function
+      dynamic: unspecified
     att&ck:
       - Defense Evasion::Virtualization/Sandbox Evasion::System Checks [T1497.001]
     mbc:

--- a/anti-analysis/obfuscation/obfuscated-with-callobfuscator.yml
+++ b/anti-analysis/obfuscation/obfuscated-with-callobfuscator.yml
@@ -6,6 +6,7 @@ rule:
       - johnk3r
     scopes:
       static: file
+      dynamic: unspecified
     att&ck:
       - Defense Evasion::Obfuscated Files or Information [T1027]
     mbc:

--- a/anti-analysis/obfuscation/obfuscated-with-callobfuscator.yml
+++ b/anti-analysis/obfuscation/obfuscated-with-callobfuscator.yml
@@ -6,7 +6,7 @@ rule:
       - johnk3r
     scopes:
       static: file
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     att&ck:
       - Defense Evasion::Obfuscated Files or Information [T1027]
     mbc:

--- a/anti-analysis/obfuscation/string/stackstring/contain-obfuscated-stackstrings.yml
+++ b/anti-analysis/obfuscation/string/stackstring/contain-obfuscated-stackstrings.yml
@@ -6,7 +6,7 @@ rule:
       - moritz.raabe@mandiant.com
     scopes:
       static: basic block
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     att&ck:
       - Defense Evasion::Obfuscated Files or Information::Indicator Removal from Tools [T1027.005]
     mbc:

--- a/anti-analysis/obfuscation/string/stackstring/contain-obfuscated-stackstrings.yml
+++ b/anti-analysis/obfuscation/string/stackstring/contain-obfuscated-stackstrings.yml
@@ -6,6 +6,7 @@ rule:
       - moritz.raabe@mandiant.com
     scopes:
       static: basic block
+      dynamic: unspecified
     att&ck:
       - Defense Evasion::Obfuscated Files or Information::Indicator Removal from Tools [T1027.005]
     mbc:

--- a/anti-analysis/packer/confuser/packed-with-confuser.yml
+++ b/anti-analysis/packer/confuser/packed-with-confuser.yml
@@ -6,7 +6,7 @@ rule:
       - william.ballenthin@mandiant.com
     scopes:
       static: file
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     att&ck:
       - Defense Evasion::Obfuscated Files or Information::Software Packing [T1027.002]
     mbc:

--- a/anti-analysis/packer/confuser/packed-with-confuser.yml
+++ b/anti-analysis/packer/confuser/packed-with-confuser.yml
@@ -6,6 +6,7 @@ rule:
       - william.ballenthin@mandiant.com
     scopes:
       static: file
+      dynamic: unspecified
     att&ck:
       - Defense Evasion::Obfuscated Files or Information::Software Packing [T1027.002]
     mbc:

--- a/anti-analysis/packer/generic/packed-with-generic-packer.yml
+++ b/anti-analysis/packer/generic/packed-with-generic-packer.yml
@@ -6,7 +6,7 @@ rule:
       - william.ballenthin@mandiant.com
     scopes:
       static: function
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     att&ck:
       - Defense Evasion::Obfuscated Files or Information::Software Packing [T1027.002]
     mbc:

--- a/anti-analysis/packer/generic/packed-with-generic-packer.yml
+++ b/anti-analysis/packer/generic/packed-with-generic-packer.yml
@@ -6,6 +6,7 @@ rule:
       - william.ballenthin@mandiant.com
     scopes:
       static: function
+      dynamic: unspecified
     att&ck:
       - Defense Evasion::Obfuscated Files or Information::Software Packing [T1027.002]
     mbc:

--- a/anti-analysis/packer/kkrunchy/packed-with-kkrunchy.yml
+++ b/anti-analysis/packer/kkrunchy/packed-with-kkrunchy.yml
@@ -6,7 +6,7 @@ rule:
       - "@_re_fox"
     scopes:
       static: file
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     att&ck:
       - Defense Evasion::Obfuscated Files or Information::Software Packing [T1027.002]
     mbc:

--- a/anti-analysis/packer/kkrunchy/packed-with-kkrunchy.yml
+++ b/anti-analysis/packer/kkrunchy/packed-with-kkrunchy.yml
@@ -6,6 +6,7 @@ rule:
       - "@_re_fox"
     scopes:
       static: file
+      dynamic: unspecified
     att&ck:
       - Defense Evasion::Obfuscated Files or Information::Software Packing [T1027.002]
     mbc:

--- a/anti-analysis/packer/nspack/packed-with-nspack.yml
+++ b/anti-analysis/packer/nspack/packed-with-nspack.yml
@@ -6,7 +6,7 @@ rule:
       - "@_re_fox"
     scopes:
       static: file
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     att&ck:
       - Defense Evasion::Obfuscated Files or Information::Software Packing [T1027.002]
     mbc:

--- a/anti-analysis/packer/nspack/packed-with-nspack.yml
+++ b/anti-analysis/packer/nspack/packed-with-nspack.yml
@@ -6,6 +6,7 @@ rule:
       - "@_re_fox"
     scopes:
       static: file
+      dynamic: unspecified
     att&ck:
       - Defense Evasion::Obfuscated Files or Information::Software Packing [T1027.002]
     mbc:

--- a/anti-analysis/packer/pebundle/packed-with-pebundle.yml
+++ b/anti-analysis/packer/pebundle/packed-with-pebundle.yml
@@ -6,7 +6,7 @@ rule:
       - "@_re_fox"
     scopes:
       static: file
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     att&ck:
       - Defense Evasion::Obfuscated Files or Information::Software Packing [T1027.002]
     mbc:

--- a/anti-analysis/packer/pebundle/packed-with-pebundle.yml
+++ b/anti-analysis/packer/pebundle/packed-with-pebundle.yml
@@ -6,6 +6,7 @@ rule:
       - "@_re_fox"
     scopes:
       static: file
+      dynamic: unspecified
     att&ck:
       - Defense Evasion::Obfuscated Files or Information::Software Packing [T1027.002]
     mbc:

--- a/anti-analysis/packer/pecompact/packed-with-pecompact.yml
+++ b/anti-analysis/packer/pecompact/packed-with-pecompact.yml
@@ -6,7 +6,7 @@ rule:
       - william.ballenthin@mandiant.com
     scopes:
       static: file
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     att&ck:
       - Defense Evasion::Obfuscated Files or Information::Software Packing [T1027.002]
     mbc:

--- a/anti-analysis/packer/pecompact/packed-with-pecompact.yml
+++ b/anti-analysis/packer/pecompact/packed-with-pecompact.yml
@@ -6,6 +6,7 @@ rule:
       - william.ballenthin@mandiant.com
     scopes:
       static: file
+      dynamic: unspecified
     att&ck:
       - Defense Evasion::Obfuscated Files or Information::Software Packing [T1027.002]
     mbc:

--- a/anti-analysis/packer/pelocknt/packed-with-pelocknt.yml
+++ b/anti-analysis/packer/pelocknt/packed-with-pelocknt.yml
@@ -6,7 +6,7 @@ rule:
       - "@_re_fox"
     scopes:
       static: file
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     att&ck:
       - Defense Evasion::Obfuscated Files or Information::Software Packing [T1027.002]
     mbc:

--- a/anti-analysis/packer/pelocknt/packed-with-pelocknt.yml
+++ b/anti-analysis/packer/pelocknt/packed-with-pelocknt.yml
@@ -6,6 +6,7 @@ rule:
       - "@_re_fox"
     scopes:
       static: file
+      dynamic: unspecified
     att&ck:
       - Defense Evasion::Obfuscated Files or Information::Software Packing [T1027.002]
     mbc:

--- a/anti-analysis/packer/pespin/packed-with-pespin.yml
+++ b/anti-analysis/packer/pespin/packed-with-pespin.yml
@@ -6,6 +6,7 @@ rule:
       - jakub.jozwiak@mandiant.com
     scopes:
       static: file
+      dynamic: unspecified
     att&ck:
       - Defense Evasion::Obfuscated Files or Information::Software Packing [T1027.002]
     mbc:

--- a/anti-analysis/packer/pespin/packed-with-pespin.yml
+++ b/anti-analysis/packer/pespin/packed-with-pespin.yml
@@ -6,7 +6,7 @@ rule:
       - jakub.jozwiak@mandiant.com
     scopes:
       static: file
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     att&ck:
       - Defense Evasion::Obfuscated Files or Information::Software Packing [T1027.002]
     mbc:

--- a/anti-analysis/packer/petite/packed-with-petite.yml
+++ b/anti-analysis/packer/petite/packed-with-petite.yml
@@ -6,7 +6,7 @@ rule:
       - "@_re_fox"
     scopes:
       static: file
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     att&ck:
       - Defense Evasion::Obfuscated Files or Information::Software Packing [T1027.002]
     mbc:

--- a/anti-analysis/packer/petite/packed-with-petite.yml
+++ b/anti-analysis/packer/petite/packed-with-petite.yml
@@ -6,6 +6,7 @@ rule:
       - "@_re_fox"
     scopes:
       static: file
+      dynamic: unspecified
     att&ck:
       - Defense Evasion::Obfuscated Files or Information::Software Packing [T1027.002]
     mbc:

--- a/anti-analysis/packer/rlpack/packed-with-rlpack.yml
+++ b/anti-analysis/packer/rlpack/packed-with-rlpack.yml
@@ -6,7 +6,7 @@ rule:
       - "@_re_fox"
     scopes:
       static: file
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     att&ck:
       - Defense Evasion::Obfuscated Files or Information::Software Packing [T1027.002]
     mbc:

--- a/anti-analysis/packer/rlpack/packed-with-rlpack.yml
+++ b/anti-analysis/packer/rlpack/packed-with-rlpack.yml
@@ -6,6 +6,7 @@ rule:
       - "@_re_fox"
     scopes:
       static: file
+      dynamic: unspecified
     att&ck:
       - Defense Evasion::Obfuscated Files or Information::Software Packing [T1027.002]
     mbc:

--- a/anti-analysis/packer/themida/packed-with-themida.yml
+++ b/anti-analysis/packer/themida/packed-with-themida.yml
@@ -6,7 +6,7 @@ rule:
       - william.ballenthin@mandiant.com
     scopes:
       static: file
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     att&ck:
       - Defense Evasion::Obfuscated Files or Information::Software Packing [T1027.002]
     mbc:

--- a/anti-analysis/packer/themida/packed-with-themida.yml
+++ b/anti-analysis/packer/themida/packed-with-themida.yml
@@ -6,6 +6,7 @@ rule:
       - william.ballenthin@mandiant.com
     scopes:
       static: file
+      dynamic: unspecified
     att&ck:
       - Defense Evasion::Obfuscated Files or Information::Software Packing [T1027.002]
     mbc:

--- a/anti-analysis/packer/y0da/packed-with-y0da-crypter.yml
+++ b/anti-analysis/packer/y0da/packed-with-y0da-crypter.yml
@@ -6,7 +6,7 @@ rule:
       - "@_re_fox"
     scopes:
       static: file
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     att&ck:
       - Defense Evasion::Obfuscated Files or Information::Software Packing [T1027.002]
     mbc:

--- a/anti-analysis/packer/y0da/packed-with-y0da-crypter.yml
+++ b/anti-analysis/packer/y0da/packed-with-y0da-crypter.yml
@@ -6,6 +6,7 @@ rule:
       - "@_re_fox"
     scopes:
       static: file
+      dynamic: unspecified
     att&ck:
       - Defense Evasion::Obfuscated Files or Information::Software Packing [T1027.002]
     mbc:

--- a/collection/credit-card/parse-credit-card-information.yml
+++ b/collection/credit-card/parse-credit-card-information.yml
@@ -6,6 +6,7 @@ rule:
       - "@_re_fox"
     scopes:
       static: function
+      dynamic: unspecified
     mbc:
       - Data::Check String [C0019]
     examples:

--- a/collection/credit-card/parse-credit-card-information.yml
+++ b/collection/credit-card/parse-credit-card-information.yml
@@ -6,7 +6,7 @@ rule:
       - "@_re_fox"
     scopes:
       static: function
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     mbc:
       - Data::Check String [C0019]
     examples:

--- a/collection/screenshot/capture-screenshot-via-keybd-event.yml
+++ b/collection/screenshot/capture-screenshot-via-keybd-event.yml
@@ -6,6 +6,7 @@ rule:
       - "@_re_fox"
     scopes:
       static: function
+      dynamic: unspecified
     att&ck:
       - Collection::Screen Capture [T1113]
     mbc:

--- a/collection/screenshot/capture-screenshot-via-keybd-event.yml
+++ b/collection/screenshot/capture-screenshot-via-keybd-event.yml
@@ -6,7 +6,7 @@ rule:
       - "@_re_fox"
     scopes:
       static: function
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     att&ck:
       - Collection::Screen Capture [T1113]
     mbc:

--- a/communication/http/client/check-http-status-code.yml
+++ b/communication/http/client/check-http-status-code.yml
@@ -6,6 +6,7 @@ rule:
       - "@mr-tz"
     scopes:
       static: function
+      dynamic: unspecified
     mbc:
       - Communication::HTTP Communication::Read Header [C0002.014]
     examples:

--- a/communication/http/client/check-http-status-code.yml
+++ b/communication/http/client/check-http-status-code.yml
@@ -6,7 +6,7 @@ rule:
       - "@mr-tz"
     scopes:
       static: function
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     mbc:
       - Communication::HTTP Communication::Read Header [C0002.014]
     examples:

--- a/communication/http/client/create-bits-job.yml
+++ b/communication/http/client/create-bits-job.yml
@@ -8,6 +8,7 @@ rule:
     description: BITS jobs can be used to download data or achieve persistence (via SetNotifyCmdLine)
     scopes:
       static: function
+      dynamic: unspecified
     att&ck:
       - Defense Evasion::BITS Jobs [T1197]
       - Persistence::BITS Jobs [T1197]

--- a/communication/http/client/create-bits-job.yml
+++ b/communication/http/client/create-bits-job.yml
@@ -8,7 +8,7 @@ rule:
     description: BITS jobs can be used to download data or achieve persistence (via SetNotifyCmdLine)
     scopes:
       static: function
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     att&ck:
       - Defense Evasion::BITS Jobs [T1197]
       - Persistence::BITS Jobs [T1197]

--- a/communication/http/client/extract-http-body.yml
+++ b/communication/http/client/extract-http-body.yml
@@ -6,6 +6,7 @@ rule:
       - matthew.williams@mandiant.com
     scopes:
       static: function
+      dynamic: unspecified
     mbc:
       - Communication::HTTP Communication::Extract Body [C0002.011]
     references:

--- a/communication/http/client/extract-http-body.yml
+++ b/communication/http/client/extract-http-body.yml
@@ -6,7 +6,7 @@ rule:
       - matthew.williams@mandiant.com
     scopes:
       static: function
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     mbc:
       - Communication::HTTP Communication::Extract Body [C0002.011]
     references:

--- a/communication/http/client/get-http-document-via-iwebbrowser2.yml
+++ b/communication/http/client/get-http-document-via-iwebbrowser2.yml
@@ -6,7 +6,7 @@ rule:
       - matthew.williams@mandiant.com
     scopes:
       static: function
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     mbc:
       - Communication::HTTP Communication::Get Response [C0002.017]
       - Communication::HTTP Communication::IWebBrowser [C0002.010]

--- a/communication/http/client/get-http-document-via-iwebbrowser2.yml
+++ b/communication/http/client/get-http-document-via-iwebbrowser2.yml
@@ -6,6 +6,7 @@ rule:
       - matthew.williams@mandiant.com
     scopes:
       static: function
+      dynamic: unspecified
     mbc:
       - Communication::HTTP Communication::Get Response [C0002.017]
       - Communication::HTTP Communication::IWebBrowser [C0002.010]

--- a/communication/http/initialize-iwebbrowser2.yml
+++ b/communication/http/initialize-iwebbrowser2.yml
@@ -6,6 +6,7 @@ rule:
       - matthew.williams@mandiant.com
     scopes:
       static: basic block
+      dynamic: unspecified
     mbc:
       - Communication::HTTP Communication::IWebBrowser [C0002.010]
     references:

--- a/communication/http/initialize-iwebbrowser2.yml
+++ b/communication/http/initialize-iwebbrowser2.yml
@@ -6,7 +6,7 @@ rule:
       - matthew.williams@mandiant.com
     scopes:
       static: basic block
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     mbc:
       - Communication::HTTP Communication::IWebBrowser [C0002.010]
     references:

--- a/communication/socket/tcp/send/obtain-transmitpackets-callback-function-via-wsaioctl.yml
+++ b/communication/socket/tcp/send/obtain-transmitpackets-callback-function-via-wsaioctl.yml
@@ -7,7 +7,7 @@ rule:
     description: The TransmitPackets function transmits in-memory data or file data over a connected socket. The TransmitPackets function uses the operating system cache manager to retrieve file data, locking memory for the minimum time required to transmit and resulting in efficient, high-performance transmission.
     scopes:
       static: function
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     mbc:
       - Communication::Socket Communication::Send TCP Data [C0001.014]
     references:

--- a/communication/socket/tcp/send/obtain-transmitpackets-callback-function-via-wsaioctl.yml
+++ b/communication/socket/tcp/send/obtain-transmitpackets-callback-function-via-wsaioctl.yml
@@ -7,6 +7,7 @@ rule:
     description: The TransmitPackets function transmits in-memory data or file data over a connected socket. The TransmitPackets function uses the operating system cache manager to retrieve file data, locking memory for the minimum time required to transmit and resulting in efficient, high-performance transmission.
     scopes:
       static: function
+      dynamic: unspecified
     mbc:
       - Communication::Socket Communication::Send TCP Data [C0001.014]
     references:

--- a/compiler/d/compiled-with-dmd.yml
+++ b/compiler/d/compiled-with-dmd.yml
@@ -6,7 +6,7 @@ rule:
       - "@_re_fox"
     scopes:
       static: file
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     references:
       - https://github.com/dlang/dmd
     examples:

--- a/compiler/d/compiled-with-dmd.yml
+++ b/compiler/d/compiled-with-dmd.yml
@@ -6,6 +6,7 @@ rule:
       - "@_re_fox"
     scopes:
       static: file
+      dynamic: unspecified
     references:
       - https://github.com/dlang/dmd
     examples:

--- a/compiler/vb/compiled-from-visual-basic.yml
+++ b/compiler/vb/compiled-from-visual-basic.yml
@@ -6,7 +6,7 @@ rule:
       - "@williballenthin"
     scopes:
       static: file
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     examples:
       - 9bca6b99e7981208af4c7925b96fb9cf
   features:

--- a/compiler/vb/compiled-from-visual-basic.yml
+++ b/compiler/vb/compiled-from-visual-basic.yml
@@ -6,6 +6,7 @@ rule:
       - "@williballenthin"
     scopes:
       static: file
+      dynamic: unspecified
     examples:
       - 9bca6b99e7981208af4c7925b96fb9cf
   features:

--- a/data-manipulation/checksum/adler32/compute-adler32-checksum.yml
+++ b/data-manipulation/checksum/adler32/compute-adler32-checksum.yml
@@ -6,7 +6,7 @@ rule:
       - matthew.williams@mandiant.com
     scopes:
       static: function
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     mbc:
       - Data::Checksum::Adler [C0032.005]
     references:

--- a/data-manipulation/checksum/adler32/compute-adler32-checksum.yml
+++ b/data-manipulation/checksum/adler32/compute-adler32-checksum.yml
@@ -6,6 +6,7 @@ rule:
       - matthew.williams@mandiant.com
     scopes:
       static: function
+      dynamic: unspecified
     mbc:
       - Data::Checksum::Adler [C0032.005]
     references:

--- a/data-manipulation/compression/compress-data-via-zlib-inflate-or-deflate.yml
+++ b/data-manipulation/compression/compress-data-via-zlib-inflate-or-deflate.yml
@@ -7,7 +7,7 @@ rule:
       - blas.kojusner@mandiant.com
     scopes:
       static: function
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     mbc:
       - Data::Compress Data [C0024]
     references:

--- a/data-manipulation/compression/compress-data-via-zlib-inflate-or-deflate.yml
+++ b/data-manipulation/compression/compress-data-via-zlib-inflate-or-deflate.yml
@@ -7,6 +7,7 @@ rule:
       - blas.kojusner@mandiant.com
     scopes:
       static: function
+      dynamic: unspecified
     mbc:
       - Data::Compress Data [C0024]
     references:

--- a/data-manipulation/compression/decompress-data-using-aplib.yml
+++ b/data-manipulation/compression/decompress-data-using-aplib.yml
@@ -9,6 +9,7 @@ rule:
     description: detects decompression function of library aPLib
     scopes:
       static: function
+      dynamic: unspecified
     mbc:
       - Data::Decompress Data::aPLib [C0025.003]
     references:

--- a/data-manipulation/compression/decompress-data-using-aplib.yml
+++ b/data-manipulation/compression/decompress-data-using-aplib.yml
@@ -9,7 +9,7 @@ rule:
     description: detects decompression function of library aPLib
     scopes:
       static: function
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     mbc:
       - Data::Decompress Data::aPLib [C0025.003]
     references:

--- a/data-manipulation/compression/decompress-data-using-lzo.yml
+++ b/data-manipulation/compression/decompress-data-using-lzo.yml
@@ -8,6 +8,7 @@ rule:
     description: detects the decompression routine from LZO
     scopes:
       static: function
+      dynamic: unspecified
     mbc:
       - Data::Decompress Data [C0025]
     references:

--- a/data-manipulation/compression/decompress-data-using-lzo.yml
+++ b/data-manipulation/compression/decompress-data-using-lzo.yml
@@ -8,7 +8,7 @@ rule:
     description: detects the decompression routine from LZO
     scopes:
       static: function
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     mbc:
       - Data::Decompress Data [C0025]
     references:

--- a/data-manipulation/compression/decompress-data-using-ucl.yml
+++ b/data-manipulation/compression/decompress-data-using-ucl.yml
@@ -6,7 +6,7 @@ rule:
       - jakub.jozwiak@mandiant.com
     scopes:
       static: function
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     mbc:
       - Data::Decompress Data [C0025]
     references:

--- a/data-manipulation/compression/decompress-data-using-ucl.yml
+++ b/data-manipulation/compression/decompress-data-using-ucl.yml
@@ -6,6 +6,7 @@ rule:
       - jakub.jozwiak@mandiant.com
     scopes:
       static: function
+      dynamic: unspecified
     mbc:
       - Data::Decompress Data [C0025]
     references:

--- a/data-manipulation/compression/decompress-data-via-iencodingfilterfactory.yml
+++ b/data-manipulation/compression/decompress-data-via-iencodingfilterfactory.yml
@@ -6,6 +6,7 @@ rule:
       - matthew.williams@mandiant.com
     scopes:
       static: function
+      dynamic: unspecified
     mbc:
       - Data::Decompress Data::IEncodingFilterFactory [C0025.002]
     references:

--- a/data-manipulation/compression/decompress-data-via-iencodingfilterfactory.yml
+++ b/data-manipulation/compression/decompress-data-via-iencodingfilterfactory.yml
@@ -6,7 +6,7 @@ rule:
       - matthew.williams@mandiant.com
     scopes:
       static: function
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     mbc:
       - Data::Decompress Data::IEncodingFilterFactory [C0025.002]
     references:

--- a/data-manipulation/encoding/base64/decode-data-using-base64-via-dword-translation-table.yml
+++ b/data-manipulation/encoding/base64/decode-data-using-base64-via-dword-translation-table.yml
@@ -7,6 +7,7 @@ rule:
       - sara.rincon@mandiant.com
     scopes:
       static: function
+      dynamic: unspecified
     att&ck:
       - Defense Evasion::Obfuscated Files or Information [T1027]
     mbc:

--- a/data-manipulation/encoding/base64/decode-data-using-base64-via-dword-translation-table.yml
+++ b/data-manipulation/encoding/base64/decode-data-using-base64-via-dword-translation-table.yml
@@ -7,7 +7,7 @@ rule:
       - sara.rincon@mandiant.com
     scopes:
       static: function
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     att&ck:
       - Defense Evasion::Obfuscated Files or Information [T1027]
     mbc:

--- a/data-manipulation/encoding/xor/encode-data-using-xor.yml
+++ b/data-manipulation/encoding/xor/encode-data-using-xor.yml
@@ -6,7 +6,7 @@ rule:
       - moritz.raabe@mandiant.com
     scopes:
       static: basic block
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     att&ck:
       - Defense Evasion::Obfuscated Files or Information [T1027]
     mbc:

--- a/data-manipulation/encoding/xor/encode-data-using-xor.yml
+++ b/data-manipulation/encoding/xor/encode-data-using-xor.yml
@@ -6,6 +6,7 @@ rule:
       - moritz.raabe@mandiant.com
     scopes:
       static: basic block
+      dynamic: unspecified
     att&ck:
       - Defense Evasion::Obfuscated Files or Information [T1027]
     mbc:

--- a/data-manipulation/encryption/aes/decrypt-data-using-aes-via-x86-extensions.yml
+++ b/data-manipulation/encryption/aes/decrypt-data-using-aes-via-x86-extensions.yml
@@ -6,6 +6,7 @@ rule:
       - moritz.raabe@mandiant.com
     scopes:
       static: function
+      dynamic: unspecified
     att&ck:
       - Defense Evasion::Deobfuscate/Decode Files or Information [T1140]
     mbc:

--- a/data-manipulation/encryption/aes/decrypt-data-using-aes-via-x86-extensions.yml
+++ b/data-manipulation/encryption/aes/decrypt-data-using-aes-via-x86-extensions.yml
@@ -6,7 +6,7 @@ rule:
       - moritz.raabe@mandiant.com
     scopes:
       static: function
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     att&ck:
       - Defense Evasion::Deobfuscate/Decode Files or Information [T1140]
     mbc:

--- a/data-manipulation/encryption/aes/encrypt-data-using-aes-mixcolumns-step.yml
+++ b/data-manipulation/encryption/aes/encrypt-data-using-aes-mixcolumns-step.yml
@@ -7,7 +7,7 @@ rule:
       - "@mr-tz"
     scopes:
       static: function
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     att&ck:
       - Defense Evasion::Obfuscated Files or Information [T1027]
     mbc:

--- a/data-manipulation/encryption/aes/encrypt-data-using-aes-mixcolumns-step.yml
+++ b/data-manipulation/encryption/aes/encrypt-data-using-aes-mixcolumns-step.yml
@@ -7,6 +7,7 @@ rule:
       - "@mr-tz"
     scopes:
       static: function
+      dynamic: unspecified
     att&ck:
       - Defense Evasion::Obfuscated Files or Information [T1027]
     mbc:

--- a/data-manipulation/encryption/aes/encrypt-data-using-aes-via-dotnet.yml
+++ b/data-manipulation/encryption/aes/encrypt-data-using-aes-via-dotnet.yml
@@ -6,6 +6,7 @@ rule:
       - william.ballenthin@mandiant.com
     scopes:
       static: file
+      dynamic: unspecified
     att&ck:
       - Defense Evasion::Obfuscated Files or Information [T1027]
     mbc:

--- a/data-manipulation/encryption/aes/encrypt-data-using-aes-via-dotnet.yml
+++ b/data-manipulation/encryption/aes/encrypt-data-using-aes-via-dotnet.yml
@@ -6,7 +6,7 @@ rule:
       - william.ballenthin@mandiant.com
     scopes:
       static: file
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     att&ck:
       - Defense Evasion::Obfuscated Files or Information [T1027]
     mbc:

--- a/data-manipulation/encryption/aes/manually-build-aes-constants.yml
+++ b/data-manipulation/encryption/aes/manually-build-aes-constants.yml
@@ -6,6 +6,7 @@ rule:
       - huynh.t.nhan@gmail.com
     scopes:
       static: function
+      dynamic: unspecified
     att&ck:
       - Defense Evasion::Obfuscated Files or Information [T1027]
     mbc:

--- a/data-manipulation/encryption/aes/manually-build-aes-constants.yml
+++ b/data-manipulation/encryption/aes/manually-build-aes-constants.yml
@@ -6,7 +6,7 @@ rule:
       - huynh.t.nhan@gmail.com
     scopes:
       static: function
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     att&ck:
       - Defense Evasion::Obfuscated Files or Information [T1027]
     mbc:

--- a/data-manipulation/encryption/des/encrypt-data-using-des.yml
+++ b/data-manipulation/encryption/des/encrypt-data-using-des.yml
@@ -7,6 +7,7 @@ rule:
       - william.ballenthin@mandiant.com
     scopes:
       static: basic block
+      dynamic: unspecified
     att&ck:
       - Defense Evasion::Obfuscated Files or Information [T1027]
     mbc:

--- a/data-manipulation/encryption/des/encrypt-data-using-des.yml
+++ b/data-manipulation/encryption/des/encrypt-data-using-des.yml
@@ -7,7 +7,7 @@ rule:
       - william.ballenthin@mandiant.com
     scopes:
       static: basic block
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     att&ck:
       - Defense Evasion::Obfuscated Files or Information [T1027]
     mbc:

--- a/data-manipulation/encryption/elliptic-curve/encrypt-data-using-curve25519.yml
+++ b/data-manipulation/encryption/elliptic-curve/encrypt-data-using-curve25519.yml
@@ -7,7 +7,7 @@ rule:
     description: Targets code that enforces Curve25519's secret key restrictions. The specification states "The legitimate users are assumed to generate independent uniform random secret keys. A user can, for example, generate 32 uniform random bytes, clear bits 0, 1, 2 of the first byte, clear bit 7 of the last byte, and set bit 6 of the last byte."
     scopes:
       static: basic block
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     att&ck:
       - Defense Evasion::Obfuscated Files or Information [T1027]
     examples:

--- a/data-manipulation/encryption/elliptic-curve/encrypt-data-using-curve25519.yml
+++ b/data-manipulation/encryption/elliptic-curve/encrypt-data-using-curve25519.yml
@@ -7,6 +7,7 @@ rule:
     description: Targets code that enforces Curve25519's secret key restrictions. The specification states "The legitimate users are assumed to generate independent uniform random secret keys. A user can, for example, generate 32 uniform random bytes, clear bits 0, 1, 2 of the first byte, clear bit 7 of the last byte, and set bit 6 of the last byte."
     scopes:
       static: basic block
+      dynamic: unspecified
     att&ck:
       - Defense Evasion::Obfuscated Files or Information [T1027]
     examples:

--- a/data-manipulation/encryption/hc-128/encrypt-data-using-hc-128-via-wolfssl.yml
+++ b/data-manipulation/encryption/hc-128/encrypt-data-using-hc-128-via-wolfssl.yml
@@ -7,7 +7,7 @@ rule:
       - blaine.stancill@mandiant.com
     scopes:
       static: basic block
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     att&ck:
       - Defense Evasion::Obfuscated Files or Information [T1027]
     mbc:

--- a/data-manipulation/encryption/hc-128/encrypt-data-using-hc-128-via-wolfssl.yml
+++ b/data-manipulation/encryption/hc-128/encrypt-data-using-hc-128-via-wolfssl.yml
@@ -7,6 +7,7 @@ rule:
       - blaine.stancill@mandiant.com
     scopes:
       static: basic block
+      dynamic: unspecified
     att&ck:
       - Defense Evasion::Obfuscated Files or Information [T1027]
     mbc:

--- a/data-manipulation/encryption/hc-128/encrypt-data-using-hc-128.yml
+++ b/data-manipulation/encryption/hc-128/encrypt-data-using-hc-128.yml
@@ -7,6 +7,7 @@ rule:
     description: Looks for instruction mnemonics associated with initialization of the HC-128 stream cipher
     scopes:
       static: basic block
+      dynamic: unspecified
     att&ck:
       - Defense Evasion::Obfuscated Files or Information [T1027]
     mbc:

--- a/data-manipulation/encryption/hc-128/encrypt-data-using-hc-128.yml
+++ b/data-manipulation/encryption/hc-128/encrypt-data-using-hc-128.yml
@@ -7,7 +7,7 @@ rule:
     description: Looks for instruction mnemonics associated with initialization of the HC-128 stream cipher
     scopes:
       static: basic block
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     att&ck:
       - Defense Evasion::Obfuscated Files or Information [T1027]
     mbc:

--- a/data-manipulation/encryption/rc4/encrypt-data-using-rc4-ksa.yml
+++ b/data-manipulation/encryption/rc4/encrypt-data-using-rc4-ksa.yml
@@ -6,7 +6,7 @@ rule:
       - moritz.raabe@mandiant.com
     scopes:
       static: function
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     att&ck:
       - Defense Evasion::Obfuscated Files or Information [T1027]
     mbc:

--- a/data-manipulation/encryption/rc4/encrypt-data-using-rc4-ksa.yml
+++ b/data-manipulation/encryption/rc4/encrypt-data-using-rc4-ksa.yml
@@ -6,6 +6,7 @@ rule:
       - moritz.raabe@mandiant.com
     scopes:
       static: function
+      dynamic: unspecified
     att&ck:
       - Defense Evasion::Obfuscated Files or Information [T1027]
     mbc:

--- a/data-manipulation/encryption/rc4/encrypt-data-using-rc4-prga.yml
+++ b/data-manipulation/encryption/rc4/encrypt-data-using-rc4-prga.yml
@@ -6,7 +6,7 @@ rule:
       - moritz.raabe@mandiant.com
     scopes:
       static: function
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     att&ck:
       - Defense Evasion::Obfuscated Files or Information [T1027]
     mbc:

--- a/data-manipulation/encryption/rc4/encrypt-data-using-rc4-prga.yml
+++ b/data-manipulation/encryption/rc4/encrypt-data-using-rc4-prga.yml
@@ -6,6 +6,7 @@ rule:
       - moritz.raabe@mandiant.com
     scopes:
       static: function
+      dynamic: unspecified
     att&ck:
       - Defense Evasion::Obfuscated Files or Information [T1027]
     mbc:

--- a/data-manipulation/encryption/rc4/encrypt-data-using-rc4-with-custom-key-via-winapi.yml
+++ b/data-manipulation/encryption/rc4/encrypt-data-using-rc4-with-custom-key-via-winapi.yml
@@ -6,7 +6,7 @@ rule:
       - blaine.stancill@mandiant.com
     scopes:
       static: function
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     att&ck:
       - Defense Evasion::Obfuscated Files or Information [T1027]
     mbc:

--- a/data-manipulation/encryption/rc4/encrypt-data-using-rc4-with-custom-key-via-winapi.yml
+++ b/data-manipulation/encryption/rc4/encrypt-data-using-rc4-with-custom-key-via-winapi.yml
@@ -6,6 +6,7 @@ rule:
       - blaine.stancill@mandiant.com
     scopes:
       static: function
+      dynamic: unspecified
     att&ck:
       - Defense Evasion::Obfuscated Files or Information [T1027]
     mbc:

--- a/data-manipulation/encryption/skipjack/encrypt-data-using-skipjack.yml
+++ b/data-manipulation/encryption/skipjack/encrypt-data-using-skipjack.yml
@@ -6,6 +6,7 @@ rule:
       - "@_re_fox"
     scopes:
       static: basic block
+      dynamic: unspecified
     att&ck:
       - Defense Evasion::Obfuscated Files or Information [T1027]
     mbc:

--- a/data-manipulation/encryption/skipjack/encrypt-data-using-skipjack.yml
+++ b/data-manipulation/encryption/skipjack/encrypt-data-using-skipjack.yml
@@ -6,7 +6,7 @@ rule:
       - "@_re_fox"
     scopes:
       static: basic block
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     att&ck:
       - Defense Evasion::Obfuscated Files or Information [T1027]
     mbc:

--- a/data-manipulation/encryption/sosemanuk/encrypt-data-using-sosemanuk.yml
+++ b/data-manipulation/encryption/sosemanuk/encrypt-data-using-sosemanuk.yml
@@ -7,6 +7,7 @@ rule:
     description: Looks for cryptographic constants associated with the Sosemanuk stream cipher
     scopes:
       static: basic block
+      dynamic: unspecified
     att&ck:
       - Defense Evasion::Obfuscated Files or Information [T1027]
     mbc:

--- a/data-manipulation/encryption/sosemanuk/encrypt-data-using-sosemanuk.yml
+++ b/data-manipulation/encryption/sosemanuk/encrypt-data-using-sosemanuk.yml
@@ -7,7 +7,7 @@ rule:
     description: Looks for cryptographic constants associated with the Sosemanuk stream cipher
     scopes:
       static: basic block
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     att&ck:
       - Defense Evasion::Obfuscated Files or Information [T1027]
     mbc:

--- a/data-manipulation/encryption/tea/decrypt-data-using-tea.yml
+++ b/data-manipulation/encryption/tea/decrypt-data-using-tea.yml
@@ -7,7 +7,7 @@ rule:
       - raymond.leong@mandiant.com
     scopes:
       static: function
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     att&ck:
       - Defense Evasion::Obfuscated Files or Information [T1027]
     mbc:

--- a/data-manipulation/encryption/tea/decrypt-data-using-tea.yml
+++ b/data-manipulation/encryption/tea/decrypt-data-using-tea.yml
@@ -7,6 +7,7 @@ rule:
       - raymond.leong@mandiant.com
     scopes:
       static: function
+      dynamic: unspecified
     att&ck:
       - Defense Evasion::Obfuscated Files or Information [T1027]
     mbc:

--- a/data-manipulation/encryption/tea/encrypt-data-using-tea.yml
+++ b/data-manipulation/encryption/tea/encrypt-data-using-tea.yml
@@ -7,7 +7,7 @@ rule:
       - raymond.leong@mandiant.com
     scopes:
       static: function
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     att&ck:
       - Defense Evasion::Obfuscated Files or Information [T1027]
     mbc:

--- a/data-manipulation/encryption/tea/encrypt-data-using-tea.yml
+++ b/data-manipulation/encryption/tea/encrypt-data-using-tea.yml
@@ -7,6 +7,7 @@ rule:
       - raymond.leong@mandiant.com
     scopes:
       static: function
+      dynamic: unspecified
     att&ck:
       - Defense Evasion::Obfuscated Files or Information [T1027]
     mbc:

--- a/data-manipulation/encryption/twofish/encrypt-data-using-twofish.yml
+++ b/data-manipulation/encryption/twofish/encrypt-data-using-twofish.yml
@@ -6,6 +6,7 @@ rule:
       - "@_re_fox"
     scopes:
       static: basic block
+      dynamic: unspecified
     att&ck:
       - Defense Evasion::Obfuscated Files or Information [T1027]
     mbc:

--- a/data-manipulation/encryption/twofish/encrypt-data-using-twofish.yml
+++ b/data-manipulation/encryption/twofish/encrypt-data-using-twofish.yml
@@ -6,7 +6,7 @@ rule:
       - "@_re_fox"
     scopes:
       static: basic block
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     att&ck:
       - Defense Evasion::Obfuscated Files or Information [T1027]
     mbc:

--- a/data-manipulation/encryption/vest/encrypt-data-using-vest.yml
+++ b/data-manipulation/encryption/vest/encrypt-data-using-vest.yml
@@ -6,6 +6,7 @@ rule:
       - "@_re_fox"
     scopes:
       static: basic block
+      dynamic: unspecified
     att&ck:
       - Defense Evasion::Obfuscated Files or Information [T1027]
     mbc:

--- a/data-manipulation/encryption/vest/encrypt-data-using-vest.yml
+++ b/data-manipulation/encryption/vest/encrypt-data-using-vest.yml
@@ -6,7 +6,7 @@ rule:
       - "@_re_fox"
     scopes:
       static: basic block
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     att&ck:
       - Defense Evasion::Obfuscated Files or Information [T1027]
     mbc:

--- a/data-manipulation/encryption/xtea/encrypt-data-using-xtea.yml
+++ b/data-manipulation/encryption/xtea/encrypt-data-using-xtea.yml
@@ -6,7 +6,7 @@ rule:
       - raymond.leong@mandiant.com
     scopes:
       static: function
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     att&ck:
       - Defense Evasion::Obfuscated Files or Information [T1027]
     mbc:

--- a/data-manipulation/encryption/xtea/encrypt-data-using-xtea.yml
+++ b/data-manipulation/encryption/xtea/encrypt-data-using-xtea.yml
@@ -6,6 +6,7 @@ rule:
       - raymond.leong@mandiant.com
     scopes:
       static: function
+      dynamic: unspecified
     att&ck:
       - Defense Evasion::Obfuscated Files or Information [T1027]
     mbc:

--- a/data-manipulation/encryption/xxtea/encrypt-data-using-xxtea.yml
+++ b/data-manipulation/encryption/xxtea/encrypt-data-using-xxtea.yml
@@ -6,7 +6,7 @@ rule:
       - raymond.leong@mandiant.com
     scopes:
       static: function
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     att&ck:
       - Defense Evasion::Obfuscated Files or Information [T1027]
     mbc:

--- a/data-manipulation/encryption/xxtea/encrypt-data-using-xxtea.yml
+++ b/data-manipulation/encryption/xxtea/encrypt-data-using-xxtea.yml
@@ -6,6 +6,7 @@ rule:
       - raymond.leong@mandiant.com
     scopes:
       static: function
+      dynamic: unspecified
     att&ck:
       - Defense Evasion::Obfuscated Files or Information [T1027]
     mbc:

--- a/data-manipulation/hashing/djb2/hash-data-using-djb2.yml
+++ b/data-manipulation/hashing/djb2/hash-data-using-djb2.yml
@@ -7,7 +7,7 @@ rule:
       - still@teamt5.org
     scopes:
       static: function
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     mbc:
       - Data::Non-Cryptographic Hash::djb2 [C0030.006]
     references:

--- a/data-manipulation/hashing/djb2/hash-data-using-djb2.yml
+++ b/data-manipulation/hashing/djb2/hash-data-using-djb2.yml
@@ -7,6 +7,7 @@ rule:
       - still@teamt5.org
     scopes:
       static: function
+      dynamic: unspecified
     mbc:
       - Data::Non-Cryptographic Hash::djb2 [C0030.006]
     references:

--- a/data-manipulation/hashing/fnv/hash-data-using-fnv.yml
+++ b/data-manipulation/hashing/fnv/hash-data-using-fnv.yml
@@ -9,7 +9,7 @@ rule:
     description: can be any Fowler-Noll-Vo (FNV) hash variant, including FNV-1, FNV-1a, FNV-0
     scopes:
       static: function
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     mbc:
       - Data::Non-Cryptographic Hash::FNV [C0030.005]
     references:

--- a/data-manipulation/hashing/fnv/hash-data-using-fnv.yml
+++ b/data-manipulation/hashing/fnv/hash-data-using-fnv.yml
@@ -9,6 +9,7 @@ rule:
     description: can be any Fowler-Noll-Vo (FNV) hash variant, including FNV-1, FNV-1a, FNV-0
     scopes:
       static: function
+      dynamic: unspecified
     mbc:
       - Data::Non-Cryptographic Hash::FNV [C0030.005]
     references:

--- a/data-manipulation/hashing/tiger/hash-data-using-tiger.yml
+++ b/data-manipulation/hashing/tiger/hash-data-using-tiger.yml
@@ -6,7 +6,7 @@ rule:
       - "@_re_fox"
     scopes:
       static: basic block
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     mbc:
       - Cryptography::Cryptographic Hash::Tiger [C0029.005]
     examples:

--- a/data-manipulation/hashing/tiger/hash-data-using-tiger.yml
+++ b/data-manipulation/hashing/tiger/hash-data-using-tiger.yml
@@ -6,6 +6,7 @@ rule:
       - "@_re_fox"
     scopes:
       static: basic block
+      dynamic: unspecified
     mbc:
       - Cryptography::Cryptographic Hash::Tiger [C0029.005]
     examples:

--- a/data-manipulation/hmac/authenticate-hmac.yml
+++ b/data-manipulation/hmac/authenticate-hmac.yml
@@ -6,6 +6,7 @@ rule:
       - moritz.raabe@mandiant.com
     scopes:
       static: function
+      dynamic: unspecified
     mbc:
       - Cryptography::Hashed Message Authentication Code [C0061]
     references:

--- a/data-manipulation/hmac/authenticate-hmac.yml
+++ b/data-manipulation/hmac/authenticate-hmac.yml
@@ -6,7 +6,7 @@ rule:
       - moritz.raabe@mandiant.com
     scopes:
       static: function
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     mbc:
       - Cryptography::Hashed Message Authentication Code [C0061]
     references:

--- a/executable/pe/export/forwarded-export.yml
+++ b/executable/pe/export/forwarded-export.yml
@@ -6,7 +6,7 @@ rule:
       - ronnie.salomonsen@mandiant.com
     scopes:
       static: file
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     att&ck:
       - Execution::Shared Modules [T1129]
     examples:

--- a/executable/pe/export/forwarded-export.yml
+++ b/executable/pe/export/forwarded-export.yml
@@ -6,6 +6,7 @@ rule:
       - ronnie.salomonsen@mandiant.com
     scopes:
       static: file
+      dynamic: unspecified
     att&ck:
       - Execution::Shared Modules [T1129]
     examples:

--- a/executable/pe/section/tls/contain-a-thread-local-storage-tls-section.yml
+++ b/executable/pe/section/tls/contain-a-thread-local-storage-tls-section.yml
@@ -6,6 +6,7 @@ rule:
       - michael.hunhoff@mandiant.com
     scopes:
       static: file
+      dynamic: unspecified
     examples:
       - Practical Malware Analysis Lab 16-02.exe_
   features:

--- a/executable/pe/section/tls/contain-a-thread-local-storage-tls-section.yml
+++ b/executable/pe/section/tls/contain-a-thread-local-storage-tls-section.yml
@@ -6,7 +6,7 @@ rule:
       - michael.hunhoff@mandiant.com
     scopes:
       static: file
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     examples:
       - Practical Malware Analysis Lab 16-02.exe_
   features:

--- a/host-interaction/driver/disable-driver-code-integrity.yml
+++ b/host-interaction/driver/disable-driver-code-integrity.yml
@@ -6,7 +6,7 @@ rule:
       - william.ballenthin@mandiant.com
     scopes:
       static: function
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     att&ck:
       - Defense Evasion::Impair Defenses::Disable or Modify Tools [T1562.001]
     mbc:

--- a/host-interaction/driver/disable-driver-code-integrity.yml
+++ b/host-interaction/driver/disable-driver-code-integrity.yml
@@ -6,6 +6,7 @@ rule:
       - william.ballenthin@mandiant.com
     scopes:
       static: function
+      dynamic: unspecified
     att&ck:
       - Defense Evasion::Impair Defenses::Disable or Modify Tools [T1562.001]
     mbc:

--- a/host-interaction/file-system/files/list/enumerate-files-recursively.yml
+++ b/host-interaction/file-system/files/list/enumerate-files-recursively.yml
@@ -7,7 +7,7 @@ rule:
       - anushka.virgaonkar@mandiant.com
     scopes:
       static: function
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     att&ck:
       - Discovery::File and Directory Discovery [T1083]
     mbc:

--- a/host-interaction/file-system/files/list/enumerate-files-recursively.yml
+++ b/host-interaction/file-system/files/list/enumerate-files-recursively.yml
@@ -7,6 +7,7 @@ rule:
       - anushka.virgaonkar@mandiant.com
     scopes:
       static: function
+      dynamic: unspecified
     att&ck:
       - Discovery::File and Directory Discovery [T1083]
     mbc:

--- a/host-interaction/firewall/modify/access-firewall-settings-via-inetfwmgr.yml
+++ b/host-interaction/firewall/modify/access-firewall-settings-via-inetfwmgr.yml
@@ -6,7 +6,7 @@ rule:
       - moritz.raabe@mandiant.com
     scopes:
       static: function
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     att&ck:
       - Discovery::Software Discovery::Security Software Discovery [T1518.001]
       - Defense Evasion::Impair Defenses::Disable or Modify System Firewall [T1562.004]

--- a/host-interaction/firewall/modify/access-firewall-settings-via-inetfwmgr.yml
+++ b/host-interaction/firewall/modify/access-firewall-settings-via-inetfwmgr.yml
@@ -6,6 +6,7 @@ rule:
       - moritz.raabe@mandiant.com
     scopes:
       static: function
+      dynamic: unspecified
     att&ck:
       - Discovery::Software Discovery::Security Software Discovery [T1518.001]
       - Defense Evasion::Impair Defenses::Disable or Modify System Firewall [T1562.004]

--- a/host-interaction/hardware/enumerate-devices-by-category.yml
+++ b/host-interaction/hardware/enumerate-devices-by-category.yml
@@ -6,6 +6,7 @@ rule:
       - "@mr-tz"
     scopes:
       static: function
+      dynamic: unspecified
     references:
       - https://learn.microsoft.com/en-us/windows/win32/api/strmif/nf-strmif-icreatedevenum-createclassenumerator
     examples:

--- a/host-interaction/hardware/enumerate-devices-by-category.yml
+++ b/host-interaction/hardware/enumerate-devices-by-category.yml
@@ -6,7 +6,7 @@ rule:
       - "@mr-tz"
     scopes:
       static: function
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     references:
       - https://learn.microsoft.com/en-us/windows/win32/api/strmif/nf-strmif-icreatedevenum-createclassenumerator
     examples:

--- a/host-interaction/hardware/storage/enumerate-disk-properties.yml
+++ b/host-interaction/hardware/storage/enumerate-disk-properties.yml
@@ -6,7 +6,7 @@ rule:
       - michael.hunhoff@mandiant.com
     scopes:
       static: function
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     att&ck:
       - Discovery::System Information Discovery [T1082]
     references:

--- a/host-interaction/hardware/storage/enumerate-disk-properties.yml
+++ b/host-interaction/hardware/storage/enumerate-disk-properties.yml
@@ -6,6 +6,7 @@ rule:
       - michael.hunhoff@mandiant.com
     scopes:
       static: function
+      dynamic: unspecified
     att&ck:
       - Discovery::System Information Discovery [T1082]
     references:

--- a/host-interaction/memory/create-new-application-domain-in-dotnet.yml
+++ b/host-interaction/memory/create-new-application-domain-in-dotnet.yml
@@ -6,6 +6,7 @@ rule:
       - jakub.jozwiak@mandiant.com
     scopes:
       static: file
+      dynamic: unspecified
     att&ck:
       - Persistence::Hijack Execution Flow [T1574]
     references:

--- a/host-interaction/memory/create-new-application-domain-in-dotnet.yml
+++ b/host-interaction/memory/create-new-application-domain-in-dotnet.yml
@@ -6,7 +6,7 @@ rule:
       - jakub.jozwiak@mandiant.com
     scopes:
       static: file
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     att&ck:
       - Persistence::Hijack Execution Flow [T1574]
     references:

--- a/host-interaction/os/version/check-os-version.yml
+++ b/host-interaction/os/version/check-os-version.yml
@@ -7,6 +7,7 @@ rule:
       - johnk3r
     scopes:
       static: function
+      dynamic: unspecified
     att&ck:
       - Discovery::System Information Discovery [T1082]
     mbc:

--- a/host-interaction/os/version/check-os-version.yml
+++ b/host-interaction/os/version/check-os-version.yml
@@ -7,7 +7,7 @@ rule:
       - johnk3r
     scopes:
       static: function
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     att&ck:
       - Discovery::System Information Discovery [T1082]
     mbc:

--- a/host-interaction/process/inject/inject-pe.yml
+++ b/host-interaction/process/inject/inject-pe.yml
@@ -6,7 +6,7 @@ rule:
       - 0x534a@mailbox.org
     scopes:
       static: function
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     att&ck:
       - Defense Evasion::Process Injection::Portable Executable Injection [T1055.002]
       - Defense Evasion::Reflective Code Loading [T1620]

--- a/host-interaction/process/inject/inject-pe.yml
+++ b/host-interaction/process/inject/inject-pe.yml
@@ -6,6 +6,7 @@ rule:
       - 0x534a@mailbox.org
     scopes:
       static: function
+      dynamic: unspecified
     att&ck:
       - Defense Evasion::Process Injection::Portable Executable Injection [T1055.002]
       - Defense Evasion::Reflective Code Loading [T1620]

--- a/host-interaction/recycle-bin/empty-recycle-bin-quietly.yml
+++ b/host-interaction/recycle-bin/empty-recycle-bin-quietly.yml
@@ -6,7 +6,7 @@ rule:
       - matthew.williams@mandiant.com
     scopes:
       static: basic block
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     att&ck:
       - Defense Evasion::Indicator Removal [T1070]
     references:

--- a/host-interaction/recycle-bin/empty-recycle-bin-quietly.yml
+++ b/host-interaction/recycle-bin/empty-recycle-bin-quietly.yml
@@ -6,6 +6,7 @@ rule:
       - matthew.williams@mandiant.com
     scopes:
       static: basic block
+      dynamic: unspecified
     att&ck:
       - Defense Evasion::Indicator Removal [T1070]
     references:

--- a/host-interaction/software/get-installed-programs.yml
+++ b/host-interaction/software/get-installed-programs.yml
@@ -7,6 +7,7 @@ rule:
       - "@_re_fox"
     scopes:
       static: function
+      dynamic: unspecified
     att&ck:
       - Discovery::Software Discovery [T1518]
     examples:

--- a/host-interaction/software/get-installed-programs.yml
+++ b/host-interaction/software/get-installed-programs.yml
@@ -7,7 +7,7 @@ rule:
       - "@_re_fox"
     scopes:
       static: function
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     att&ck:
       - Discovery::Software Discovery [T1518]
     examples:

--- a/host-interaction/uac/bypass/bypass-uac-via-icmluautil.yml
+++ b/host-interaction/uac/bypass/bypass-uac-via-icmluautil.yml
@@ -6,7 +6,7 @@ rule:
       - anamaria.martinezgom@mandiant.com
     scopes:
       static: function
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     att&ck:
       - Defense Evasion::Abuse Elevation Control Mechanism::Bypass User Account Control [T1548.002]
     references:

--- a/host-interaction/uac/bypass/bypass-uac-via-icmluautil.yml
+++ b/host-interaction/uac/bypass/bypass-uac-via-icmluautil.yml
@@ -6,6 +6,7 @@ rule:
       - anamaria.martinezgom@mandiant.com
     scopes:
       static: function
+      dynamic: unspecified
     att&ck:
       - Defense Evasion::Abuse Elevation Control Mechanism::Bypass User Account Control [T1548.002]
     references:

--- a/host-interaction/uac/bypass/bypass-uac-via-rpc.yml
+++ b/host-interaction/uac/bypass/bypass-uac-via-rpc.yml
@@ -7,7 +7,7 @@ rule:
       - david@edeca.net
     scopes:
       static: function
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     att&ck:
       - Defense Evasion::Abuse Elevation Control Mechanism::Bypass User Account Control [T1548.002]
     references:

--- a/host-interaction/uac/bypass/bypass-uac-via-rpc.yml
+++ b/host-interaction/uac/bypass/bypass-uac-via-rpc.yml
@@ -7,6 +7,7 @@ rule:
       - david@edeca.net
     scopes:
       static: function
+      dynamic: unspecified
     att&ck:
       - Defense Evasion::Abuse Elevation Control Mechanism::Bypass User Account Control [T1548.002]
     references:

--- a/host-interaction/wmi/connect-to-wmi-namespace-via-wbemlocator.yml
+++ b/host-interaction/wmi/connect-to-wmi-namespace-via-wbemlocator.yml
@@ -7,7 +7,7 @@ rule:
       - michael.hunhoff@mandiant.com
     scopes:
       static: function
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     att&ck:
       - Execution::Windows Management Instrumentation [T1047]
     examples:

--- a/host-interaction/wmi/connect-to-wmi-namespace-via-wbemlocator.yml
+++ b/host-interaction/wmi/connect-to-wmi-namespace-via-wbemlocator.yml
@@ -7,6 +7,7 @@ rule:
       - michael.hunhoff@mandiant.com
     scopes:
       static: function
+      dynamic: unspecified
     att&ck:
       - Execution::Windows Management Instrumentation [T1047]
     examples:

--- a/lib/calculate-modulo-256-via-x86-assembly.yml
+++ b/lib/calculate-modulo-256-via-x86-assembly.yml
@@ -6,7 +6,7 @@ rule:
     lib: 'true'
     scopes:
       static: instruction
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     mbc:
       - Data::Modulo [C0058]
     examples:

--- a/lib/calculate-modulo-256-via-x86-assembly.yml
+++ b/lib/calculate-modulo-256-via-x86-assembly.yml
@@ -6,6 +6,7 @@ rule:
     lib: 'true'
     scopes:
       static: instruction
+      dynamic: unspecified
     mbc:
       - Data::Modulo [C0058]
     examples:

--- a/lib/contain-loop.yml
+++ b/lib/contain-loop.yml
@@ -6,7 +6,7 @@ rule:
     lib: 'true'
     scopes:
       static: function
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     examples:
       - 08AC667C65D36D6542917655571E61C8:0x406EAA
   features:

--- a/lib/contain-loop.yml
+++ b/lib/contain-loop.yml
@@ -6,6 +6,7 @@ rule:
     lib: 'true'
     scopes:
       static: function
+      dynamic: unspecified
     examples:
       - 08AC667C65D36D6542917655571E61C8:0x406EAA
   features:

--- a/lib/contain-pusha-popa-sequence.yml
+++ b/lib/contain-pusha-popa-sequence.yml
@@ -6,6 +6,7 @@ rule:
     lib: 'true'
     scopes:
       static: function
+      dynamic: unspecified
     examples:
       - a5c70086b3bc4fe64f4e7a0aa452e620:0x35007200
   features:

--- a/lib/contain-pusha-popa-sequence.yml
+++ b/lib/contain-pusha-popa-sequence.yml
@@ -6,7 +6,7 @@ rule:
     lib: 'true'
     scopes:
       static: function
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     examples:
       - a5c70086b3bc4fe64f4e7a0aa452e620:0x35007200
   features:

--- a/lib/peb-access.yml
+++ b/lib/peb-access.yml
@@ -6,6 +6,7 @@ rule:
     lib: 'true'
     scopes:
       static: basic block
+      dynamic: unspecified
     mbc:
       - Anti-Behavioral Analysis::Debugger Detection::Process Environment Block [B0001.019]
     references:

--- a/lib/peb-access.yml
+++ b/lib/peb-access.yml
@@ -6,7 +6,7 @@ rule:
     lib: 'true'
     scopes:
       static: basic block
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     mbc:
       - Anti-Behavioral Analysis::Debugger Detection::Process Environment Block [B0001.019]
     references:

--- a/lib/validate-payment-card-number-using-luhn-algorithm-with-lookup-table.yml
+++ b/lib/validate-payment-card-number-using-luhn-algorithm-with-lookup-table.yml
@@ -6,7 +6,7 @@ rule:
     lib: 'true'
     scopes:
       static: function
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     mbc:
       - Data::Checksum::Luhn [C0032.002]
     examples:

--- a/lib/validate-payment-card-number-using-luhn-algorithm-with-lookup-table.yml
+++ b/lib/validate-payment-card-number-using-luhn-algorithm-with-lookup-table.yml
@@ -6,6 +6,7 @@ rule:
     lib: 'true'
     scopes:
       static: function
+      dynamic: unspecified
     mbc:
       - Data::Checksum::Luhn [C0032.002]
     examples:

--- a/lib/validate-payment-card-number-using-luhn-algorithm-with-no-lookup-table.yml
+++ b/lib/validate-payment-card-number-using-luhn-algorithm-with-no-lookup-table.yml
@@ -6,7 +6,7 @@ rule:
     lib: 'true'
     scopes:
       static: function
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     mbc:
       - Data::Checksum::Luhn [C0032.002]
     examples:

--- a/lib/validate-payment-card-number-using-luhn-algorithm-with-no-lookup-table.yml
+++ b/lib/validate-payment-card-number-using-luhn-algorithm-with-no-lookup-table.yml
@@ -6,6 +6,7 @@ rule:
     lib: 'true'
     scopes:
       static: function
+      dynamic: unspecified
     mbc:
       - Data::Checksum::Luhn [C0032.002]
     examples:

--- a/linking/runtime-linking/access-peb-ldr_data.yml
+++ b/linking/runtime-linking/access-peb-ldr_data.yml
@@ -6,7 +6,7 @@ rule:
       - moritz.raabe@mandiant.com
     scopes:
       static: basic block
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     att&ck:
       - Execution::Shared Modules [T1129]
     references:

--- a/linking/runtime-linking/access-peb-ldr_data.yml
+++ b/linking/runtime-linking/access-peb-ldr_data.yml
@@ -6,6 +6,7 @@ rule:
       - moritz.raabe@mandiant.com
     scopes:
       static: basic block
+      dynamic: unspecified
     att&ck:
       - Execution::Shared Modules [T1129]
     references:

--- a/linking/runtime-linking/get-kernel32-base-address.yml
+++ b/linking/runtime-linking/get-kernel32-base-address.yml
@@ -6,7 +6,7 @@ rule:
       - moritz.raabe@mandiant.com
     scopes:
       static: basic block
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     att&ck:
       - Execution::Shared Modules [T1129]
     references:

--- a/linking/runtime-linking/get-kernel32-base-address.yml
+++ b/linking/runtime-linking/get-kernel32-base-address.yml
@@ -6,6 +6,7 @@ rule:
       - moritz.raabe@mandiant.com
     scopes:
       static: basic block
+      dynamic: unspecified
     att&ck:
       - Execution::Shared Modules [T1129]
     references:

--- a/linking/runtime-linking/get-ntdll-base-address.yml
+++ b/linking/runtime-linking/get-ntdll-base-address.yml
@@ -6,7 +6,7 @@ rule:
       - moritz.raabe@mandiant.com
     scopes:
       static: basic block
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     att&ck:
       - Execution::Shared Modules [T1129]
     references:

--- a/linking/runtime-linking/get-ntdll-base-address.yml
+++ b/linking/runtime-linking/get-ntdll-base-address.yml
@@ -6,6 +6,7 @@ rule:
       - moritz.raabe@mandiant.com
     scopes:
       static: basic block
+      dynamic: unspecified
     att&ck:
       - Execution::Shared Modules [T1129]
     references:

--- a/linking/static/msdetours/linked-against-microsoft-detours.yml
+++ b/linking/static/msdetours/linked-against-microsoft-detours.yml
@@ -6,7 +6,7 @@ rule:
       - moritz.raabe@mandiant.com
     scopes:
       static: file
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     att&ck:
       - Defense Evasion::Hijack Execution Flow [T1574]
     references:

--- a/linking/static/msdetours/linked-against-microsoft-detours.yml
+++ b/linking/static/msdetours/linked-against-microsoft-detours.yml
@@ -6,6 +6,7 @@ rule:
       - moritz.raabe@mandiant.com
     scopes:
       static: file
+      dynamic: unspecified
     att&ck:
       - Defense Evasion::Hijack Execution Flow [T1574]
     references:

--- a/load-code/dotnet/execute-dotnet-assembly-via-clr-host.yml
+++ b/load-code/dotnet/execute-dotnet-assembly-via-clr-host.yml
@@ -8,6 +8,7 @@ rule:
     description: may be used to evade hooks or hinder analysis
     scopes:
       static: function
+      dynamic: unspecified
     references:
       - https://github.com/TheWover/donut/blob/master/DonutTest/rundotnet.cpp
     examples:

--- a/load-code/dotnet/execute-dotnet-assembly-via-clr-host.yml
+++ b/load-code/dotnet/execute-dotnet-assembly-via-clr-host.yml
@@ -8,7 +8,7 @@ rule:
     description: may be used to evade hooks or hinder analysis
     scopes:
       static: function
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     references:
       - https://github.com/TheWover/donut/blob/master/DonutTest/rundotnet.cpp
     examples:

--- a/load-code/execute-vbscript-javascript-or-jscript-in-memory.yml
+++ b/load-code/execute-vbscript-javascript-or-jscript-in-memory.yml
@@ -8,6 +8,7 @@ rule:
     description: the sample may execute 32-bit VBScript, JavaScript, or JScript (32-bit)
     scopes:
       static: function
+      dynamic: unspecified
     references:
       - https://gist.github.com/odzhan/d18145b9538a3653be2f9a580b53b063
     examples:

--- a/load-code/execute-vbscript-javascript-or-jscript-in-memory.yml
+++ b/load-code/execute-vbscript-javascript-or-jscript-in-memory.yml
@@ -8,7 +8,7 @@ rule:
     description: the sample may execute 32-bit VBScript, JavaScript, or JScript (32-bit)
     scopes:
       static: function
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     references:
       - https://gist.github.com/odzhan/d18145b9538a3653be2f9a580b53b063
     examples:

--- a/load-code/pe/enumerate-pe-sections.yml
+++ b/load-code/pe/enumerate-pe-sections.yml
@@ -7,6 +7,7 @@ rule:
       - "@mr-tz"
     scopes:
       static: function
+      dynamic: unspecified
     mbc:
       - Discovery::Code Discovery::Enumerate PE Sections [B0046.001]
     references:

--- a/load-code/pe/enumerate-pe-sections.yml
+++ b/load-code/pe/enumerate-pe-sections.yml
@@ -7,7 +7,7 @@ rule:
       - "@mr-tz"
     scopes:
       static: function
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     mbc:
       - Discovery::Code Discovery::Enumerate PE Sections [B0046.001]
     references:

--- a/load-code/pe/inject-dll-reflectively.yml
+++ b/load-code/pe/inject-dll-reflectively.yml
@@ -6,6 +6,7 @@ rule:
       - "@Ana06"
     scopes:
       static: function
+      dynamic: unspecified
     att&ck:
       - Defense Evasion::Process Injection::Dynamic-link Library Injection [T1055.001]
       - Defense Evasion::Reflective Code Loading [T1620]

--- a/load-code/pe/inject-dll-reflectively.yml
+++ b/load-code/pe/inject-dll-reflectively.yml
@@ -6,7 +6,7 @@ rule:
       - "@Ana06"
     scopes:
       static: function
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     att&ck:
       - Defense Evasion::Process Injection::Dynamic-link Library Injection [T1055.001]
       - Defense Evasion::Reflective Code Loading [T1620]

--- a/load-code/pe/parse-pe-header.yml
+++ b/load-code/pe/parse-pe-header.yml
@@ -6,7 +6,7 @@ rule:
       - moritz.raabe@mandiant.com
     scopes:
       static: function
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     att&ck:
       - Execution::Shared Modules [T1129]
     examples:

--- a/load-code/pe/parse-pe-header.yml
+++ b/load-code/pe/parse-pe-header.yml
@@ -6,6 +6,7 @@ rule:
       - moritz.raabe@mandiant.com
     scopes:
       static: function
+      dynamic: unspecified
     att&ck:
       - Execution::Shared Modules [T1129]
     examples:

--- a/load-code/pe/rebuild-import-table.yml
+++ b/load-code/pe/rebuild-import-table.yml
@@ -6,7 +6,7 @@ rule:
       - "@Ana06"
     scopes:
       static: function
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     mbc:
       - Defense Evasion::Hijack Execution Flow::Import Address Table Hooking [F0015.003]
     references:

--- a/load-code/pe/rebuild-import-table.yml
+++ b/load-code/pe/rebuild-import-table.yml
@@ -6,6 +6,7 @@ rule:
       - "@Ana06"
     scopes:
       static: function
+      dynamic: unspecified
     mbc:
       - Defense Evasion::Hijack Execution Flow::Import Address Table Hooking [F0015.003]
     references:

--- a/load-code/pe/resolve-function-by-parsing-pe-exports.yml
+++ b/load-code/pe/resolve-function-by-parsing-pe-exports.yml
@@ -6,7 +6,7 @@ rule:
       - sara-rn
     scopes:
       static: function
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     examples:
       - 73CE04892E5F39EC82B00C02FC04C70F:0x406BA1
   features:

--- a/load-code/pe/resolve-function-by-parsing-pe-exports.yml
+++ b/load-code/pe/resolve-function-by-parsing-pe-exports.yml
@@ -6,6 +6,7 @@ rule:
       - sara-rn
     scopes:
       static: function
+      dynamic: unspecified
     examples:
       - 73CE04892E5F39EC82B00C02FC04C70F:0x406BA1
   features:

--- a/nursery/authenticate-data-with-md5-mac.yml
+++ b/nursery/authenticate-data-with-md5-mac.yml
@@ -6,7 +6,7 @@ rule:
       - william.ballenthin@mandiant.com
     scopes:
       static: function
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     mbc:
       - Cryptography::Cryptographic Hash::MD5 [C0029.001]
     references:

--- a/nursery/authenticate-data-with-md5-mac.yml
+++ b/nursery/authenticate-data-with-md5-mac.yml
@@ -6,6 +6,7 @@ rule:
       - william.ballenthin@mandiant.com
     scopes:
       static: function
+      dynamic: unspecified
     mbc:
       - Cryptography::Cryptographic Hash::MD5 [C0029.001]
     references:

--- a/nursery/check-for-minimum-number-of-windows-on-screen.yml
+++ b/nursery/check-for-minimum-number-of-windows-on-screen.yml
@@ -6,7 +6,7 @@ rule:
       - echernofsky@google.com
     scopes:
       static: basic block
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     att&ck:
       - Defense Evasion::Virtualization/Sandbox Evasion::System Checks [T1497.001]
     references:

--- a/nursery/check-for-minimum-number-of-windows-on-screen.yml
+++ b/nursery/check-for-minimum-number-of-windows-on-screen.yml
@@ -6,6 +6,7 @@ rule:
       - echernofsky@google.com
     scopes:
       static: basic block
+      dynamic: unspecified
     att&ck:
       - Defense Evasion::Virtualization/Sandbox Evasion::System Checks [T1497.001]
     references:

--- a/nursery/check-for-vm-using-instruction-vpcext.yml
+++ b/nursery/check-for-vm-using-instruction-vpcext.yml
@@ -8,7 +8,7 @@ rule:
     description: Detects virtualization using VPCEXT (visual property container extender) instruction. Execution of this instruction will cause an illegal instruction exception outside of a virtual environment otherwise return 0
     scopes:
       static: function
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     att&ck:
       - Defense Evasion::Virtualization/Sandbox Evasion [T1497]
     mbc:

--- a/nursery/check-for-vm-using-instruction-vpcext.yml
+++ b/nursery/check-for-vm-using-instruction-vpcext.yml
@@ -8,6 +8,7 @@ rule:
     description: Detects virtualization using VPCEXT (visual property container extender) instruction. Execution of this instruction will cause an illegal instruction exception outside of a virtual environment otherwise return 0
     scopes:
       static: function
+      dynamic: unspecified
     att&ck:
       - Defense Evasion::Virtualization/Sandbox Evasion [T1497]
     mbc:

--- a/nursery/check-thread-yield-allowed.yml
+++ b/nursery/check-thread-yield-allowed.yml
@@ -6,7 +6,7 @@ rule:
       - michael.hunhoff@mandiant.com
     scopes:
       static: function
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     mbc:
       - Anti-Behavioral Analysis::Debugger Detection::NtYieldExecution/SwitchToThread [B0001.015]
     references:

--- a/nursery/check-thread-yield-allowed.yml
+++ b/nursery/check-thread-yield-allowed.yml
@@ -6,6 +6,7 @@ rule:
       - michael.hunhoff@mandiant.com
     scopes:
       static: function
+      dynamic: unspecified
     mbc:
       - Anti-Behavioral Analysis::Debugger Detection::NtYieldExecution/SwitchToThread [B0001.015]
     references:

--- a/nursery/compiled-with-exescript.yml
+++ b/nursery/compiled-with-exescript.yml
@@ -6,6 +6,7 @@ rule:
       - jonathanlepore@google.com
     scopes:
       static: file
+      dynamic: unspecified
     references:
       - https://www.hide-folder.com/overview/hf_7.html
   features:

--- a/nursery/compiled-with-exescript.yml
+++ b/nursery/compiled-with-exescript.yml
@@ -6,7 +6,7 @@ rule:
       - jonathanlepore@google.com
     scopes:
       static: file
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     references:
       - https://www.hide-folder.com/overview/hf_7.html
   features:

--- a/nursery/covertly-decode-and-write-data-to-windows-directory-using-indirect-calls.yml
+++ b/nursery/covertly-decode-and-write-data-to-windows-directory-using-indirect-calls.yml
@@ -6,6 +6,7 @@ rule:
       - dan.kelly@mandiant.com
     scopes:
       static: function
+      dynamic: unspecified
     att&ck:
       - Defense Evasion::Obfuscated Files or Information [T1027]
     mbc:

--- a/nursery/covertly-decode-and-write-data-to-windows-directory-using-indirect-calls.yml
+++ b/nursery/covertly-decode-and-write-data-to-windows-directory-using-indirect-calls.yml
@@ -6,7 +6,7 @@ rule:
       - dan.kelly@mandiant.com
     scopes:
       static: function
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     att&ck:
       - Defense Evasion::Obfuscated Files or Information [T1027]
     mbc:

--- a/nursery/encrypt-data-using-aes-via-x86-extensions.yml
+++ b/nursery/encrypt-data-using-aes-via-x86-extensions.yml
@@ -6,7 +6,7 @@ rule:
       - moritz.raabe@mandiant.com
     scopes:
       static: function
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     att&ck:
       - Defense Evasion::Obfuscated Files or Information [T1027]
     mbc:

--- a/nursery/encrypt-data-using-aes-via-x86-extensions.yml
+++ b/nursery/encrypt-data-using-aes-via-x86-extensions.yml
@@ -6,6 +6,7 @@ rule:
       - moritz.raabe@mandiant.com
     scopes:
       static: function
+      dynamic: unspecified
     att&ck:
       - Defense Evasion::Obfuscated Files or Information [T1027]
     mbc:

--- a/nursery/encrypt-data-using-aes.yml
+++ b/nursery/encrypt-data-using-aes.yml
@@ -8,6 +8,7 @@ rule:
       - Ivan Kwiatkowski (@JusticeRage)
     scopes:
       static: function
+      dynamic: unspecified
     att&ck:
       - Defense Evasion::Obfuscated Files or Information [T1027]
     mbc:

--- a/nursery/encrypt-data-using-aes.yml
+++ b/nursery/encrypt-data-using-aes.yml
@@ -8,7 +8,7 @@ rule:
       - Ivan Kwiatkowski (@JusticeRage)
     scopes:
       static: function
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     att&ck:
       - Defense Evasion::Obfuscated Files or Information [T1027]
     mbc:

--- a/nursery/encrypt-data-using-fakem-cipher.yml
+++ b/nursery/encrypt-data-using-fakem-cipher.yml
@@ -8,7 +8,7 @@ rule:
     description: Detect custom encryption cipher used by FAKEM malware family
     scopes:
       static: basic block
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     att&ck:
       - Defense Evasion::Obfuscated Files or Information [T1027]
     mbc:

--- a/nursery/encrypt-data-using-fakem-cipher.yml
+++ b/nursery/encrypt-data-using-fakem-cipher.yml
@@ -8,6 +8,7 @@ rule:
     description: Detect custom encryption cipher used by FAKEM malware family
     scopes:
       static: basic block
+      dynamic: unspecified
     att&ck:
       - Defense Evasion::Obfuscated Files or Information [T1027]
     mbc:

--- a/nursery/encrypt-data-using-openssl-dsa.yml
+++ b/nursery/encrypt-data-using-openssl-dsa.yml
@@ -6,6 +6,7 @@ rule:
       - Ana06
     scopes:
       static: function
+      dynamic: unspecified
     references:
       - https://github.com/openssl/openssl/blob/fdc5043d58900663b493147298e64f11353b35fe/crypto/objects/obj_dat.h
   features:

--- a/nursery/encrypt-data-using-openssl-dsa.yml
+++ b/nursery/encrypt-data-using-openssl-dsa.yml
@@ -6,7 +6,7 @@ rule:
       - Ana06
     scopes:
       static: function
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     references:
       - https://github.com/openssl/openssl/blob/fdc5043d58900663b493147298e64f11353b35fe/crypto/objects/obj_dat.h
   features:

--- a/nursery/encrypt-data-using-openssl-ecdsa.yml
+++ b/nursery/encrypt-data-using-openssl-ecdsa.yml
@@ -6,6 +6,7 @@ rule:
       - Ana06
     scopes:
       static: function
+      dynamic: unspecified
     references:
       - https://github.com/openssl/openssl/blob/fdc5043d58900663b493147298e64f11353b35fe/crypto/objects/obj_dat.h
   features:

--- a/nursery/encrypt-data-using-openssl-ecdsa.yml
+++ b/nursery/encrypt-data-using-openssl-ecdsa.yml
@@ -6,7 +6,7 @@ rule:
       - Ana06
     scopes:
       static: function
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     references:
       - https://github.com/openssl/openssl/blob/fdc5043d58900663b493147298e64f11353b35fe/crypto/objects/obj_dat.h
   features:

--- a/nursery/encrypt-data-using-openssl-rsa.yml
+++ b/nursery/encrypt-data-using-openssl-rsa.yml
@@ -6,6 +6,7 @@ rule:
       - Ana06
     scopes:
       static: function
+      dynamic: unspecified
     mbc:
       - Cryptography::Encrypt Data::RSA [C0027.011]
     references:

--- a/nursery/encrypt-data-using-openssl-rsa.yml
+++ b/nursery/encrypt-data-using-openssl-rsa.yml
@@ -6,7 +6,7 @@ rule:
       - Ana06
     scopes:
       static: function
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     mbc:
       - Cryptography::Encrypt Data::RSA [C0027.011]
     references:

--- a/nursery/execute-shellcode-via-indirect-call.yml
+++ b/nursery/execute-shellcode-via-indirect-call.yml
@@ -6,6 +6,7 @@ rule:
       - ronnie.salomonsen@mandiant.com
     scopes:
       static: function
+      dynamic: unspecified
     mbc:
       - Memory::Allocate Memory [C0007]
   features:

--- a/nursery/execute-shellcode-via-indirect-call.yml
+++ b/nursery/execute-shellcode-via-indirect-call.yml
@@ -6,7 +6,7 @@ rule:
       - ronnie.salomonsen@mandiant.com
     scopes:
       static: function
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     mbc:
       - Memory::Allocate Memory [C0007]
   features:

--- a/nursery/execute-syscall-instruction.yml
+++ b/nursery/execute-syscall-instruction.yml
@@ -8,6 +8,7 @@ rule:
     description: may be used to evade hooks or hinder analysis
     scopes:
       static: basic block
+      dynamic: unspecified
     references:
       - https://github.com/j00ru/windows-syscalls
   features:

--- a/nursery/execute-syscall-instruction.yml
+++ b/nursery/execute-syscall-instruction.yml
@@ -8,7 +8,7 @@ rule:
     description: may be used to evade hooks or hinder analysis
     scopes:
       static: basic block
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     references:
       - https://github.com/j00ru/windows-syscalls
   features:

--- a/nursery/generate-random-numbers-using-the-delphi-lcg.yml
+++ b/nursery/generate-random-numbers-using-the-delphi-lcg.yml
@@ -6,7 +6,7 @@ rule:
       - william.ballenthin@mandiant.com
     scopes:
       static: basic block
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     mbc:
       - Cryptography::Generate Pseudo-random Sequence [C0021]
     references:

--- a/nursery/generate-random-numbers-using-the-delphi-lcg.yml
+++ b/nursery/generate-random-numbers-using-the-delphi-lcg.yml
@@ -6,6 +6,7 @@ rule:
       - william.ballenthin@mandiant.com
     scopes:
       static: basic block
+      dynamic: unspecified
     mbc:
       - Cryptography::Generate Pseudo-random Sequence [C0021]
     references:

--- a/nursery/get-os-version-in-dotnet.yml
+++ b/nursery/get-os-version-in-dotnet.yml
@@ -6,7 +6,7 @@ rule:
       - michael.hunhoff@mandiant.com
     scopes:
       static: basic block
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     att&ck:
       - Discovery::System Information Discovery [T1082]
   features:

--- a/nursery/get-os-version-in-dotnet.yml
+++ b/nursery/get-os-version-in-dotnet.yml
@@ -6,6 +6,7 @@ rule:
       - michael.hunhoff@mandiant.com
     scopes:
       static: basic block
+      dynamic: unspecified
     att&ck:
       - Discovery::System Information Discovery [T1082]
   features:

--- a/nursery/hash-data-using-aphash.yml
+++ b/nursery/hash-data-using-aphash.yml
@@ -6,7 +6,7 @@ rule:
       - "@_re_fox"
     scopes:
       static: function
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     mbc:
       - Data::Non-Cryptographic Hash [C0030]
     references:

--- a/nursery/hash-data-using-aphash.yml
+++ b/nursery/hash-data-using-aphash.yml
@@ -6,6 +6,7 @@ rule:
       - "@_re_fox"
     scopes:
       static: function
+      dynamic: unspecified
     mbc:
       - Data::Non-Cryptographic Hash [C0030]
     references:

--- a/nursery/hash-data-using-jshash.yml
+++ b/nursery/hash-data-using-jshash.yml
@@ -6,7 +6,7 @@ rule:
       - "@_re_fox"
     scopes:
       static: function
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     mbc:
       - Data::Non-Cryptographic Hash [C0030]
     references:

--- a/nursery/hash-data-using-jshash.yml
+++ b/nursery/hash-data-using-jshash.yml
@@ -6,6 +6,7 @@ rule:
       - "@_re_fox"
     scopes:
       static: function
+      dynamic: unspecified
     mbc:
       - Data::Non-Cryptographic Hash [C0030]
     references:

--- a/nursery/hash-data-using-murmur2.yml
+++ b/nursery/hash-data-using-murmur2.yml
@@ -6,7 +6,7 @@ rule:
       - william.ballenthin@mandiant.com
     scopes:
       static: instruction
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     references:
       - https://github.com/abrandoned/murmur2/blob/master/MurmurHash2.c
   features:

--- a/nursery/hash-data-using-murmur2.yml
+++ b/nursery/hash-data-using-murmur2.yml
@@ -6,6 +6,7 @@ rule:
       - william.ballenthin@mandiant.com
     scopes:
       static: instruction
+      dynamic: unspecified
     references:
       - https://github.com/abrandoned/murmur2/blob/master/MurmurHash2.c
   features:

--- a/nursery/hash-data-using-rshash.yml
+++ b/nursery/hash-data-using-rshash.yml
@@ -6,7 +6,7 @@ rule:
       - "@_re_fox"
     scopes:
       static: function
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     mbc:
       - Data::Non-Cryptographic Hash [C0030]
     references:

--- a/nursery/hash-data-using-rshash.yml
+++ b/nursery/hash-data-using-rshash.yml
@@ -6,6 +6,7 @@ rule:
       - "@_re_fox"
     scopes:
       static: function
+      dynamic: unspecified
     mbc:
       - Data::Non-Cryptographic Hash [C0030]
     references:

--- a/nursery/hash-data-using-whirlpool.yml
+++ b/nursery/hash-data-using-whirlpool.yml
@@ -6,7 +6,7 @@ rule:
       - william.ballenthin@mandiant.com
     scopes:
       static: function
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     mbc:
       - Cryptography::Cryptographic Hash [C0029]
     references:

--- a/nursery/hash-data-using-whirlpool.yml
+++ b/nursery/hash-data-using-whirlpool.yml
@@ -6,6 +6,7 @@ rule:
       - william.ballenthin@mandiant.com
     scopes:
       static: function
+      dynamic: unspecified
     mbc:
       - Cryptography::Cryptographic Hash [C0029]
     references:

--- a/nursery/hooked-by-api-override.yml
+++ b/nursery/hooked-by-api-override.yml
@@ -6,6 +6,7 @@ rule:
       - william.ballenthin@mandiant.com
     scopes:
       static: file
+      dynamic: unspecified
     references:
       - https://www.hexacorn.com/blog/2012/10/14/random-stats-from-1-2m-samples-pe-section-names/
       - http://jacquelin.potier.free.fr/winapioverride32/

--- a/nursery/hooked-by-api-override.yml
+++ b/nursery/hooked-by-api-override.yml
@@ -6,7 +6,7 @@ rule:
       - william.ballenthin@mandiant.com
     scopes:
       static: file
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     references:
       - https://www.hexacorn.com/blog/2012/10/14/random-stats-from-1-2m-samples-pe-section-names/
       - http://jacquelin.potier.free.fr/winapioverride32/

--- a/nursery/implement-com-dll.yml
+++ b/nursery/implement-com-dll.yml
@@ -6,7 +6,7 @@ rule:
       - moritz.raabe@mandiant.com
     scopes:
       static: file
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     references:
       - https://learn.microsoft.com/en-us/windows/win32/api/combaseapi/nf-combaseapi-dllgetclassobject
   features:

--- a/nursery/implement-com-dll.yml
+++ b/nursery/implement-com-dll.yml
@@ -6,6 +6,7 @@ rule:
       - moritz.raabe@mandiant.com
     scopes:
       static: file
+      dynamic: unspecified
     references:
       - https://learn.microsoft.com/en-us/windows/win32/api/combaseapi/nf-combaseapi-dllgetclassobject
   features:

--- a/nursery/log-keystrokes-via-raw-input-data.yml
+++ b/nursery/log-keystrokes-via-raw-input-data.yml
@@ -7,6 +7,7 @@ rule:
       - michael.hunhoff@mandiant.com
     scopes:
       static: function
+      dynamic: unspecified
     att&ck:
       - Collection::Input Capture::Keylogging [T1056.001]
   features:

--- a/nursery/log-keystrokes-via-raw-input-data.yml
+++ b/nursery/log-keystrokes-via-raw-input-data.yml
@@ -7,7 +7,7 @@ rule:
       - michael.hunhoff@mandiant.com
     scopes:
       static: function
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     att&ck:
       - Collection::Input Capture::Keylogging [T1056.001]
   features:

--- a/nursery/obfuscated-with-koivm.yml
+++ b/nursery/obfuscated-with-koivm.yml
@@ -6,6 +6,7 @@ rule:
       - michael.hunhoff@mandiant.com
     scopes:
       static: file
+      dynamic: unspecified
     att&ck:
       - Defense Evasion::Obfuscated Files or Information [T1027]
     mbc:

--- a/nursery/obfuscated-with-koivm.yml
+++ b/nursery/obfuscated-with-koivm.yml
@@ -6,7 +6,7 @@ rule:
       - michael.hunhoff@mandiant.com
     scopes:
       static: file
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     att&ck:
       - Defense Evasion::Obfuscated Files or Information [T1027]
     mbc:

--- a/nursery/packaged-as-a-createinstall-installer.yml
+++ b/nursery/packaged-as-a-createinstall-installer.yml
@@ -6,7 +6,7 @@ rule:
       - william.ballenthin@mandiant.com
     scopes:
       static: file
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     references:
       - https://www.createinstall.com/
       - https://www.hexacorn.com/blog/2012/10/14/random-stats-from-1-2m-samples-pe-section-names/

--- a/nursery/packaged-as-a-createinstall-installer.yml
+++ b/nursery/packaged-as-a-createinstall-installer.yml
@@ -6,6 +6,7 @@ rule:
       - william.ballenthin@mandiant.com
     scopes:
       static: file
+      dynamic: unspecified
     references:
       - https://www.createinstall.com/
       - https://www.hexacorn.com/blog/2012/10/14/random-stats-from-1-2m-samples-pe-section-names/

--- a/nursery/packaged-as-a-pintool.yml
+++ b/nursery/packaged-as-a-pintool.yml
@@ -6,6 +6,7 @@ rule:
       - william.ballenthin@mandiant.com
     scopes:
       static: file
+      dynamic: unspecified
     references:
       - https://software.intel.com/content/www/us/en/develop/articles/pin-a-dynamic-binary-instrumentation-tool.html
       - https://www.hexacorn.com/blog/2012/10/14/random-stats-from-1-2m-samples-pe-section-names/

--- a/nursery/packaged-as-a-pintool.yml
+++ b/nursery/packaged-as-a-pintool.yml
@@ -6,7 +6,7 @@ rule:
       - william.ballenthin@mandiant.com
     scopes:
       static: file
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     references:
       - https://software.intel.com/content/www/us/en/develop/articles/pin-a-dynamic-binary-instrumentation-tool.html
       - https://www.hexacorn.com/blog/2012/10/14/random-stats-from-1-2m-samples-pe-section-names/

--- a/nursery/packaged-as-a-winzip-self-extracting-archive.yml
+++ b/nursery/packaged-as-a-winzip-self-extracting-archive.yml
@@ -6,6 +6,7 @@ rule:
       - william.ballenthin@mandiant.com
     scopes:
       static: file
+      dynamic: unspecified
     references:
       - https://www.hexacorn.com/blog/2016/12/15/pe-section-names-re-visited/
   features:

--- a/nursery/packaged-as-a-winzip-self-extracting-archive.yml
+++ b/nursery/packaged-as-a-winzip-self-extracting-archive.yml
@@ -6,7 +6,7 @@ rule:
       - william.ballenthin@mandiant.com
     scopes:
       static: file
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     references:
       - https://www.hexacorn.com/blog/2016/12/15/pe-section-names-re-visited/
   features:

--- a/nursery/packed-with-ccg.yml
+++ b/nursery/packed-with-ccg.yml
@@ -6,7 +6,7 @@ rule:
       - william.ballenthin@mandiant.com
     scopes:
       static: file
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     att&ck:
       - Defense Evasion::Obfuscated Files or Information::Software Packing [T1027.002]
     mbc:

--- a/nursery/packed-with-ccg.yml
+++ b/nursery/packed-with-ccg.yml
@@ -6,6 +6,7 @@ rule:
       - william.ballenthin@mandiant.com
     scopes:
       static: file
+      dynamic: unspecified
     att&ck:
       - Defense Evasion::Obfuscated Files or Information::Software Packing [T1027.002]
     mbc:

--- a/nursery/packed-with-crunch.yml
+++ b/nursery/packed-with-crunch.yml
@@ -6,7 +6,7 @@ rule:
       - william.ballenthin@mandiant.com
     scopes:
       static: file
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     att&ck:
       - Defense Evasion::Obfuscated Files or Information::Software Packing [T1027.002]
     mbc:

--- a/nursery/packed-with-crunch.yml
+++ b/nursery/packed-with-crunch.yml
@@ -6,6 +6,7 @@ rule:
       - william.ballenthin@mandiant.com
     scopes:
       static: file
+      dynamic: unspecified
     att&ck:
       - Defense Evasion::Obfuscated Files or Information::Software Packing [T1027.002]
     mbc:

--- a/nursery/packed-with-dragon-armor.yml
+++ b/nursery/packed-with-dragon-armor.yml
@@ -6,7 +6,7 @@ rule:
       - william.ballenthin@mandiant.com
     scopes:
       static: file
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     att&ck:
       - Defense Evasion::Obfuscated Files or Information::Software Packing [T1027.002]
     mbc:

--- a/nursery/packed-with-dragon-armor.yml
+++ b/nursery/packed-with-dragon-armor.yml
@@ -6,6 +6,7 @@ rule:
       - william.ballenthin@mandiant.com
     scopes:
       static: file
+      dynamic: unspecified
     att&ck:
       - Defense Evasion::Obfuscated Files or Information::Software Packing [T1027.002]
     mbc:

--- a/nursery/packed-with-enigma.yml
+++ b/nursery/packed-with-enigma.yml
@@ -6,7 +6,7 @@ rule:
       - william.ballenthin@mandiant.com
     scopes:
       static: file
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     att&ck:
       - Defense Evasion::Obfuscated Files or Information::Software Packing [T1027.002]
     mbc:

--- a/nursery/packed-with-enigma.yml
+++ b/nursery/packed-with-enigma.yml
@@ -6,6 +6,7 @@ rule:
       - william.ballenthin@mandiant.com
     scopes:
       static: file
+      dynamic: unspecified
     att&ck:
       - Defense Evasion::Obfuscated Files or Information::Software Packing [T1027.002]
     mbc:

--- a/nursery/packed-with-epack.yml
+++ b/nursery/packed-with-epack.yml
@@ -6,7 +6,7 @@ rule:
       - william.ballenthin@mandiant.com
     scopes:
       static: file
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     att&ck:
       - Defense Evasion::Obfuscated Files or Information::Software Packing [T1027.002]
     mbc:

--- a/nursery/packed-with-epack.yml
+++ b/nursery/packed-with-epack.yml
@@ -6,6 +6,7 @@ rule:
       - william.ballenthin@mandiant.com
     scopes:
       static: file
+      dynamic: unspecified
     att&ck:
       - Defense Evasion::Obfuscated Files or Information::Software Packing [T1027.002]
     mbc:

--- a/nursery/packed-with-maskpe.yml
+++ b/nursery/packed-with-maskpe.yml
@@ -6,7 +6,7 @@ rule:
       - william.ballenthin@mandiant.com
     scopes:
       static: file
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     att&ck:
       - Defense Evasion::Obfuscated Files or Information::Software Packing [T1027.002]
     mbc:

--- a/nursery/packed-with-maskpe.yml
+++ b/nursery/packed-with-maskpe.yml
@@ -6,6 +6,7 @@ rule:
       - william.ballenthin@mandiant.com
     scopes:
       static: file
+      dynamic: unspecified
     att&ck:
       - Defense Evasion::Obfuscated Files or Information::Software Packing [T1027.002]
     mbc:

--- a/nursery/packed-with-mew.yml
+++ b/nursery/packed-with-mew.yml
@@ -6,7 +6,7 @@ rule:
       - william.ballenthin@mandiant.com
     scopes:
       static: file
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     att&ck:
       - Defense Evasion::Obfuscated Files or Information::Software Packing [T1027.002]
     mbc:

--- a/nursery/packed-with-mew.yml
+++ b/nursery/packed-with-mew.yml
@@ -6,6 +6,7 @@ rule:
       - william.ballenthin@mandiant.com
     scopes:
       static: file
+      dynamic: unspecified
     att&ck:
       - Defense Evasion::Obfuscated Files or Information::Software Packing [T1027.002]
     mbc:

--- a/nursery/packed-with-mpress.yml
+++ b/nursery/packed-with-mpress.yml
@@ -6,7 +6,7 @@ rule:
       - william.ballenthin@mandiant.com
     scopes:
       static: file
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     att&ck:
       - Defense Evasion::Obfuscated Files or Information::Software Packing [T1027.002]
     mbc:

--- a/nursery/packed-with-mpress.yml
+++ b/nursery/packed-with-mpress.yml
@@ -6,6 +6,7 @@ rule:
       - william.ballenthin@mandiant.com
     scopes:
       static: file
+      dynamic: unspecified
     att&ck:
       - Defense Evasion::Obfuscated Files or Information::Software Packing [T1027.002]
     mbc:

--- a/nursery/packed-with-neolite.yml
+++ b/nursery/packed-with-neolite.yml
@@ -6,7 +6,7 @@ rule:
       - william.ballenthin@mandiant.com
     scopes:
       static: file
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     att&ck:
       - Defense Evasion::Obfuscated Files or Information::Software Packing [T1027.002]
     mbc:

--- a/nursery/packed-with-neolite.yml
+++ b/nursery/packed-with-neolite.yml
@@ -6,6 +6,7 @@ rule:
       - william.ballenthin@mandiant.com
     scopes:
       static: file
+      dynamic: unspecified
     att&ck:
       - Defense Evasion::Obfuscated Files or Information::Software Packing [T1027.002]
     mbc:

--- a/nursery/packed-with-pepack.yml
+++ b/nursery/packed-with-pepack.yml
@@ -6,7 +6,7 @@ rule:
       - william.ballenthin@mandiant.com
     scopes:
       static: file
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     att&ck:
       - Defense Evasion::Obfuscated Files or Information::Software Packing [T1027.002]
     mbc:

--- a/nursery/packed-with-pepack.yml
+++ b/nursery/packed-with-pepack.yml
@@ -6,6 +6,7 @@ rule:
       - william.ballenthin@mandiant.com
     scopes:
       static: file
+      dynamic: unspecified
     att&ck:
       - Defense Evasion::Obfuscated Files or Information::Software Packing [T1027.002]
     mbc:

--- a/nursery/packed-with-perplex.yml
+++ b/nursery/packed-with-perplex.yml
@@ -6,7 +6,7 @@ rule:
       - william.ballenthin@mandiant.com
     scopes:
       static: file
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     att&ck:
       - Defense Evasion::Obfuscated Files or Information::Software Packing [T1027.002]
     mbc:

--- a/nursery/packed-with-perplex.yml
+++ b/nursery/packed-with-perplex.yml
@@ -6,6 +6,7 @@ rule:
       - william.ballenthin@mandiant.com
     scopes:
       static: file
+      dynamic: unspecified
     att&ck:
       - Defense Evasion::Obfuscated Files or Information::Software Packing [T1027.002]
     mbc:

--- a/nursery/packed-with-procrypt.yml
+++ b/nursery/packed-with-procrypt.yml
@@ -6,7 +6,7 @@ rule:
       - william.ballenthin@mandiant.com
     scopes:
       static: file
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     att&ck:
       - Defense Evasion::Obfuscated Files or Information::Software Packing [T1027.002]
     mbc:

--- a/nursery/packed-with-procrypt.yml
+++ b/nursery/packed-with-procrypt.yml
@@ -6,6 +6,7 @@ rule:
       - william.ballenthin@mandiant.com
     scopes:
       static: file
+      dynamic: unspecified
     att&ck:
       - Defense Evasion::Obfuscated Files or Information::Software Packing [T1027.002]
     mbc:

--- a/nursery/packed-with-rpcrypt.yml
+++ b/nursery/packed-with-rpcrypt.yml
@@ -6,7 +6,7 @@ rule:
       - william.ballenthin@mandiant.com
     scopes:
       static: file
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     att&ck:
       - Defense Evasion::Obfuscated Files or Information::Software Packing [T1027.002]
     mbc:

--- a/nursery/packed-with-rpcrypt.yml
+++ b/nursery/packed-with-rpcrypt.yml
@@ -6,6 +6,7 @@ rule:
       - william.ballenthin@mandiant.com
     scopes:
       static: file
+      dynamic: unspecified
     att&ck:
       - Defense Evasion::Obfuscated Files or Information::Software Packing [T1027.002]
     mbc:

--- a/nursery/packed-with-seausfx.yml
+++ b/nursery/packed-with-seausfx.yml
@@ -6,7 +6,7 @@ rule:
       - william.ballenthin@mandiant.com
     scopes:
       static: file
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     att&ck:
       - Defense Evasion::Obfuscated Files or Information::Software Packing [T1027.002]
     mbc:

--- a/nursery/packed-with-seausfx.yml
+++ b/nursery/packed-with-seausfx.yml
@@ -6,6 +6,7 @@ rule:
       - william.ballenthin@mandiant.com
     scopes:
       static: file
+      dynamic: unspecified
     att&ck:
       - Defense Evasion::Obfuscated Files or Information::Software Packing [T1027.002]
     mbc:

--- a/nursery/packed-with-shrinker.yml
+++ b/nursery/packed-with-shrinker.yml
@@ -6,7 +6,7 @@ rule:
       - william.ballenthin@mandiant.com
     scopes:
       static: file
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     att&ck:
       - Defense Evasion::Obfuscated Files or Information::Software Packing [T1027.002]
     mbc:

--- a/nursery/packed-with-shrinker.yml
+++ b/nursery/packed-with-shrinker.yml
@@ -6,6 +6,7 @@ rule:
       - william.ballenthin@mandiant.com
     scopes:
       static: file
+      dynamic: unspecified
     att&ck:
       - Defense Evasion::Obfuscated Files or Information::Software Packing [T1027.002]
     mbc:

--- a/nursery/packed-with-simple-pack.yml
+++ b/nursery/packed-with-simple-pack.yml
@@ -6,7 +6,7 @@ rule:
       - william.ballenthin@mandiant.com
     scopes:
       static: file
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     att&ck:
       - Defense Evasion::Obfuscated Files or Information::Software Packing [T1027.002]
     mbc:

--- a/nursery/packed-with-simple-pack.yml
+++ b/nursery/packed-with-simple-pack.yml
@@ -6,6 +6,7 @@ rule:
       - william.ballenthin@mandiant.com
     scopes:
       static: file
+      dynamic: unspecified
     att&ck:
       - Defense Evasion::Obfuscated Files or Information::Software Packing [T1027.002]
     mbc:

--- a/nursery/packed-with-starforce.yml
+++ b/nursery/packed-with-starforce.yml
@@ -6,7 +6,7 @@ rule:
       - william.ballenthin@mandiant.com
     scopes:
       static: file
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     att&ck:
       - Defense Evasion::Obfuscated Files or Information::Software Packing [T1027.002]
     mbc:

--- a/nursery/packed-with-starforce.yml
+++ b/nursery/packed-with-starforce.yml
@@ -6,6 +6,7 @@ rule:
       - william.ballenthin@mandiant.com
     scopes:
       static: file
+      dynamic: unspecified
     att&ck:
       - Defense Evasion::Obfuscated Files or Information::Software Packing [T1027.002]
     mbc:

--- a/nursery/packed-with-svkp.yml
+++ b/nursery/packed-with-svkp.yml
@@ -6,7 +6,7 @@ rule:
       - william.ballenthin@mandiant.com
     scopes:
       static: file
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     att&ck:
       - Defense Evasion::Obfuscated Files or Information::Software Packing [T1027.002]
     mbc:

--- a/nursery/packed-with-svkp.yml
+++ b/nursery/packed-with-svkp.yml
@@ -6,6 +6,7 @@ rule:
       - william.ballenthin@mandiant.com
     scopes:
       static: file
+      dynamic: unspecified
     att&ck:
       - Defense Evasion::Obfuscated Files or Information::Software Packing [T1027.002]
     mbc:

--- a/nursery/packed-with-tsuloader.yml
+++ b/nursery/packed-with-tsuloader.yml
@@ -6,7 +6,7 @@ rule:
       - william.ballenthin@mandiant.com
     scopes:
       static: file
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     att&ck:
       - Defense Evasion::Obfuscated Files or Information::Software Packing [T1027.002]
     mbc:

--- a/nursery/packed-with-tsuloader.yml
+++ b/nursery/packed-with-tsuloader.yml
@@ -6,6 +6,7 @@ rule:
       - william.ballenthin@mandiant.com
     scopes:
       static: file
+      dynamic: unspecified
     att&ck:
       - Defense Evasion::Obfuscated Files or Information::Software Packing [T1027.002]
     mbc:

--- a/nursery/packed-with-vprotect.yml
+++ b/nursery/packed-with-vprotect.yml
@@ -6,7 +6,7 @@ rule:
       - william.ballenthin@mandiant.com
     scopes:
       static: file
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     att&ck:
       - Defense Evasion::Obfuscated Files or Information::Software Packing [T1027.002]
     mbc:

--- a/nursery/packed-with-vprotect.yml
+++ b/nursery/packed-with-vprotect.yml
@@ -6,6 +6,7 @@ rule:
       - william.ballenthin@mandiant.com
     scopes:
       static: file
+      dynamic: unspecified
     att&ck:
       - Defense Evasion::Obfuscated Files or Information::Software Packing [T1027.002]
     mbc:

--- a/nursery/packed-with-wwpack.yml
+++ b/nursery/packed-with-wwpack.yml
@@ -6,7 +6,7 @@ rule:
       - william.ballenthin@mandiant.com
     scopes:
       static: file
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     att&ck:
       - Defense Evasion::Obfuscated Files or Information::Software Packing [T1027.002]
     mbc:

--- a/nursery/packed-with-wwpack.yml
+++ b/nursery/packed-with-wwpack.yml
@@ -6,6 +6,7 @@ rule:
       - william.ballenthin@mandiant.com
     scopes:
       static: file
+      dynamic: unspecified
     att&ck:
       - Defense Evasion::Obfuscated Files or Information::Software Packing [T1027.002]
     mbc:

--- a/nursery/rebuilt-by-imprec.yml
+++ b/nursery/rebuilt-by-imprec.yml
@@ -6,6 +6,7 @@ rule:
       - william.ballenthin@mandiant.com
     scopes:
       static: file
+      dynamic: unspecified
     references:
       - https://www.hexacorn.com/blog/2012/10/14/random-stats-from-1-2m-samples-pe-section-names/
   features:

--- a/nursery/rebuilt-by-imprec.yml
+++ b/nursery/rebuilt-by-imprec.yml
@@ -6,7 +6,7 @@ rule:
       - william.ballenthin@mandiant.com
     scopes:
       static: file
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     references:
       - https://www.hexacorn.com/blog/2012/10/14/random-stats-from-1-2m-samples-pe-section-names/
   features:

--- a/nursery/reference-aes-constants.yml
+++ b/nursery/reference-aes-constants.yml
@@ -6,6 +6,7 @@ rule:
       - william.ballenthin@mandiant.com
     scopes:
       static: function
+      dynamic: unspecified
     att&ck:
       - Defense Evasion::Obfuscated Files or Information [T1027]
   features:

--- a/nursery/reference-aes-constants.yml
+++ b/nursery/reference-aes-constants.yml
@@ -6,7 +6,7 @@ rule:
       - william.ballenthin@mandiant.com
     scopes:
       static: function
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     att&ck:
       - Defense Evasion::Obfuscated Files or Information [T1027]
   features:

--- a/nursery/reference-processor-manufacturer-constants.yml
+++ b/nursery/reference-processor-manufacturer-constants.yml
@@ -6,6 +6,7 @@ rule:
       - matthew.williams@mandiant.com
     scopes:
       static: basic block
+      dynamic: unspecified
     att&ck:
       - Defense Evasion::Virtualization/Sandbox Evasion::System Checks [T1497.001]
     mbc:

--- a/nursery/reference-processor-manufacturer-constants.yml
+++ b/nursery/reference-processor-manufacturer-constants.yml
@@ -6,7 +6,7 @@ rule:
       - matthew.williams@mandiant.com
     scopes:
       static: basic block
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     att&ck:
       - Defense Evasion::Virtualization/Sandbox Evasion::System Checks [T1497.001]
     mbc:

--- a/nursery/reference-the-vmware-io-port.yml
+++ b/nursery/reference-the-vmware-io-port.yml
@@ -6,6 +6,7 @@ rule:
       - matthew.williams@mandiant.com
     scopes:
       static: function
+      dynamic: unspecified
     att&ck:
       - Defense Evasion::Virtualization/Sandbox Evasion::System Checks [T1497.001]
     mbc:

--- a/nursery/reference-the-vmware-io-port.yml
+++ b/nursery/reference-the-vmware-io-port.yml
@@ -6,7 +6,7 @@ rule:
       - matthew.williams@mandiant.com
     scopes:
       static: function
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     att&ck:
       - Defense Evasion::Virtualization/Sandbox Evasion::System Checks [T1497.001]
     mbc:

--- a/nursery/schedule-task-via-itaskservice.yml
+++ b/nursery/schedule-task-via-itaskservice.yml
@@ -6,6 +6,7 @@ rule:
       - michael.hunhoff@mandiant.com
     scopes:
       static: function
+      dynamic: unspecified
     att&ck:
       - Persistence::Scheduled Task/Job::Scheduled Task [T1053.005]
   features:

--- a/nursery/schedule-task-via-itaskservice.yml
+++ b/nursery/schedule-task-via-itaskservice.yml
@@ -6,7 +6,7 @@ rule:
       - michael.hunhoff@mandiant.com
     scopes:
       static: function
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     att&ck:
       - Persistence::Scheduled Task/Job::Scheduled Task [T1053.005]
   features:

--- a/persistence/act-as-dhcp-server-callout-dll.yml
+++ b/persistence/act-as-dhcp-server-callout-dll.yml
@@ -6,7 +6,7 @@ rule:
       - jakub.jozwiak@mandiant.com
     scopes:
       static: file
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     att&ck:
       - Persistence::Server Software Component [T1505]
     references:

--- a/persistence/act-as-dhcp-server-callout-dll.yml
+++ b/persistence/act-as-dhcp-server-callout-dll.yml
@@ -6,6 +6,7 @@ rule:
       - jakub.jozwiak@mandiant.com
     scopes:
       static: file
+      dynamic: unspecified
     att&ck:
       - Persistence::Server Software Component [T1505]
     references:

--- a/persistence/act-as-dns-server-plugin-dll.yml
+++ b/persistence/act-as-dns-server-plugin-dll.yml
@@ -6,7 +6,7 @@ rule:
       - jakub.jozwiak@mandiant.com
     scopes:
       static: file
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     att&ck:
       - Persistence::Server Software Component [T1505]
     references:

--- a/persistence/act-as-dns-server-plugin-dll.yml
+++ b/persistence/act-as-dns-server-plugin-dll.yml
@@ -6,6 +6,7 @@ rule:
       - jakub.jozwiak@mandiant.com
     scopes:
       static: file
+      dynamic: unspecified
     att&ck:
       - Persistence::Server Software Component [T1505]
     references:

--- a/persistence/authentication-process/act-as-credential-manager-dll.yml
+++ b/persistence/authentication-process/act-as-credential-manager-dll.yml
@@ -6,6 +6,7 @@ rule:
       - jakub.jozwiak@mandiant.com
     scopes:
       static: file
+      dynamic: unspecified
     att&ck:
       - Persistence::Modify Authentication Process::Network Provider DLL [T1556.008]
     examples:

--- a/persistence/authentication-process/act-as-credential-manager-dll.yml
+++ b/persistence/authentication-process/act-as-credential-manager-dll.yml
@@ -6,7 +6,7 @@ rule:
       - jakub.jozwiak@mandiant.com
     scopes:
       static: file
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     att&ck:
       - Persistence::Modify Authentication Process::Network Provider DLL [T1556.008]
     examples:

--- a/persistence/authentication-process/act-as-password-filter-dll.yml
+++ b/persistence/authentication-process/act-as-password-filter-dll.yml
@@ -6,7 +6,7 @@ rule:
       - jakub.jozwiak@mandiant.com
     scopes:
       static: file
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     att&ck:
       - Persistence::Modify Authentication Process::Password Filter DLL [T1556.002]
     examples:

--- a/persistence/authentication-process/act-as-password-filter-dll.yml
+++ b/persistence/authentication-process/act-as-password-filter-dll.yml
@@ -6,6 +6,7 @@ rule:
       - jakub.jozwiak@mandiant.com
     scopes:
       static: file
+      dynamic: unspecified
     att&ck:
       - Persistence::Modify Authentication Process::Password Filter DLL [T1556.002]
     examples:

--- a/persistence/authentication-process/act-as-security-support-provider-dll.yml
+++ b/persistence/authentication-process/act-as-security-support-provider-dll.yml
@@ -6,7 +6,7 @@ rule:
       - jakub.jozwiak@mandiant.com
     scopes:
       static: file
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     att&ck:
       - Persistence::Boot or Logon Autostart Execution::Security Support Provider [T1547.005]
     references:

--- a/persistence/authentication-process/act-as-security-support-provider-dll.yml
+++ b/persistence/authentication-process/act-as-security-support-provider-dll.yml
@@ -6,6 +6,7 @@ rule:
       - jakub.jozwiak@mandiant.com
     scopes:
       static: file
+      dynamic: unspecified
     att&ck:
       - Persistence::Boot or Logon Autostart Execution::Security Support Provider [T1547.005]
     references:

--- a/persistence/authentication-process/act-as-subauthentication-package-dll.yml
+++ b/persistence/authentication-process/act-as-subauthentication-package-dll.yml
@@ -6,7 +6,7 @@ rule:
       - jakub.jozwiak@mandiant.com
     scopes:
       static: file
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     att&ck:
       - Persistence::Boot or Logon Autostart Execution::Authentication Package [T1547.002]
     references:

--- a/persistence/authentication-process/act-as-subauthentication-package-dll.yml
+++ b/persistence/authentication-process/act-as-subauthentication-package-dll.yml
@@ -6,6 +6,7 @@ rule:
       - jakub.jozwiak@mandiant.com
     scopes:
       static: file
+      dynamic: unspecified
     att&ck:
       - Persistence::Boot or Logon Autostart Execution::Authentication Package [T1547.002]
     references:

--- a/persistence/create-shortcut-via-ishelllink.yml
+++ b/persistence/create-shortcut-via-ishelllink.yml
@@ -6,7 +6,7 @@ rule:
       - matthew.williams@mandiant.com
     scopes:
       static: function
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     att&ck:
       - Persistence::Boot or Logon Autostart Execution::Shortcut Modification [T1547.009]
     references:

--- a/persistence/create-shortcut-via-ishelllink.yml
+++ b/persistence/create-shortcut-via-ishelllink.yml
@@ -6,6 +6,7 @@ rule:
       - matthew.williams@mandiant.com
     scopes:
       static: function
+      dynamic: unspecified
     att&ck:
       - Persistence::Boot or Logon Autostart Execution::Shortcut Modification [T1547.009]
     references:

--- a/persistence/iis/persist-via-isapi-extension.yml
+++ b/persistence/iis/persist-via-isapi-extension.yml
@@ -7,6 +7,7 @@ rule:
     description: Internet Server Application Programming Interface (ISAPI) extensions and filters can be installed to examine and/or modify incoming and outgoing IIS web requests.
     scopes:
       static: file
+      dynamic: unspecified
     att&ck:
       - Persistence::Server Software Component::IIS Components [T1505.004]
     examples:

--- a/persistence/iis/persist-via-isapi-extension.yml
+++ b/persistence/iis/persist-via-isapi-extension.yml
@@ -7,7 +7,7 @@ rule:
     description: Internet Server Application Programming Interface (ISAPI) extensions and filters can be installed to examine and/or modify incoming and outgoing IIS web requests.
     scopes:
       static: file
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     att&ck:
       - Persistence::Server Software Component::IIS Components [T1505.004]
     examples:

--- a/persistence/office/act-as-excel-xll-add-in.yml
+++ b/persistence/office/act-as-excel-xll-add-in.yml
@@ -6,7 +6,7 @@ rule:
       - jakub.jozwiak@mandiant.com
     scopes:
       static: file
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     att&ck:
       - Persistence::Office Application Startup::Add-ins [T1137.006]
     references:

--- a/persistence/office/act-as-excel-xll-add-in.yml
+++ b/persistence/office/act-as-excel-xll-add-in.yml
@@ -6,6 +6,7 @@ rule:
       - jakub.jozwiak@mandiant.com
     scopes:
       static: file
+      dynamic: unspecified
     att&ck:
       - Persistence::Office Application Startup::Add-ins [T1137.006]
     references:

--- a/persistence/office/act-as-office-com-add-in.yml
+++ b/persistence/office/act-as-office-com-add-in.yml
@@ -6,7 +6,7 @@ rule:
       - jakub.jozwiak@mandiant.com
     scopes:
       static: file
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     att&ck:
       - Persistence::Office Application Startup::Add-ins [T1137.006]
     references:

--- a/persistence/office/act-as-office-com-add-in.yml
+++ b/persistence/office/act-as-office-com-add-in.yml
@@ -6,6 +6,7 @@ rule:
       - jakub.jozwiak@mandiant.com
     scopes:
       static: file
+      dynamic: unspecified
     att&ck:
       - Persistence::Office Application Startup::Add-ins [T1137.006]
     references:

--- a/persistence/office/act-as-word-wll-add-in.yml
+++ b/persistence/office/act-as-word-wll-add-in.yml
@@ -6,7 +6,7 @@ rule:
       - jakub.jozwiak@mandiant.com
     scopes:
       static: file
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     att&ck:
       - Persistence::Office Application Startup::Add-ins [T1137.006]
     references:

--- a/persistence/office/act-as-word-wll-add-in.yml
+++ b/persistence/office/act-as-word-wll-add-in.yml
@@ -6,6 +6,7 @@ rule:
       - jakub.jozwiak@mandiant.com
     scopes:
       static: file
+      dynamic: unspecified
     att&ck:
       - Persistence::Office Application Startup::Add-ins [T1137.006]
     references:

--- a/persistence/scheduled-tasks/schedule-task-via-itaskscheduler.yml
+++ b/persistence/scheduled-tasks/schedule-task-via-itaskscheduler.yml
@@ -6,6 +6,7 @@ rule:
       - moritz.raabe@mandiant.com
     scopes:
       static: function
+      dynamic: unspecified
     att&ck:
       - Persistence::Scheduled Task/Job::Scheduled Task [T1053.005]
     examples:

--- a/persistence/scheduled-tasks/schedule-task-via-itaskscheduler.yml
+++ b/persistence/scheduled-tasks/schedule-task-via-itaskscheduler.yml
@@ -6,7 +6,7 @@ rule:
       - moritz.raabe@mandiant.com
     scopes:
       static: function
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     att&ck:
       - Persistence::Scheduled Task/Job::Scheduled Task [T1053.005]
     examples:

--- a/runtime/dotnet/execute-via-dotnet-startup-hook.yml
+++ b/runtime/dotnet/execute-via-dotnet-startup-hook.yml
@@ -6,7 +6,7 @@ rule:
       - william.ballenthin@mandiant.com
     scopes:
       static: file
-      dynamic: unspecified
+      dynamic: unspecified   # rule hasn't been migrated yet
     references:
       - https://rastamouse.me/net-startup-hooks/
       - https://github.com/dotnet/runtime/blob/main/docs/design/features/host-startup-hook.md

--- a/runtime/dotnet/execute-via-dotnet-startup-hook.yml
+++ b/runtime/dotnet/execute-via-dotnet-startup-hook.yml
@@ -6,6 +6,7 @@ rule:
       - william.ballenthin@mandiant.com
     scopes:
       static: file
+      dynamic: unspecified
     references:
       - https://rastamouse.me/net-startup-hooks/
       - https://github.com/dotnet/runtime/blob/main/docs/design/features/host-startup-hook.md


### PR DESCRIPTION
We have enforced that all rules must specify both the static and dynamic scopes. This PR updates the initial version of the rules (the one generated automatically) to have both scopes specified. Merging this PR should fix the failing the tests at https://github.com/mandiant/capa/pull/1697