### PR TITLE
Add remaining dynamic-syntax rules missing the  dynamic scope

### DIFF
--- a/nursery/enumerate-browser-history.yml
+++ b/nursery/enumerate-browser-history.yml
@@ -6,6 +6,7 @@ rule:
       - michael.hunhoff@mandiant.com
     scopes:
       static: function
+      dynamic: unspecified   # rule hasn't been migrated yet
   features:
     - and:
       - api: ole32.CoCreateInstance

--- a/nursery/hash-data-using-crc32b.yml
+++ b/nursery/hash-data-using-crc32b.yml
@@ -6,6 +6,7 @@ rule:
       - moritz.raabe@mandiant.com
     scopes:
       static: function
+      dynamic: unspecified   # rule hasn't been migrated yet
   features:
     - and:
       - number: 0x4C11DB7

--- a/nursery/hash-data-using-sha1-via-x86-extensions.yml
+++ b/nursery/hash-data-using-sha1-via-x86-extensions.yml
@@ -6,6 +6,7 @@ rule:
       - "@_re_fox"
     scopes:
       static: basic block
+      dynamic: unspecified   # rule hasn't been migrated yet
   features:
     - or:
       - mnemonic: sha1rnds4 = Perform Four Rounds of SHA1 Operation

--- a/nursery/hash-data-using-sha256-via-x86-extensions.yml
+++ b/nursery/hash-data-using-sha256-via-x86-extensions.yml
@@ -6,6 +6,7 @@ rule:
       - "@_re_fox"
     scopes:
       static: basic block
+      dynamic: unsupported
   features:
     - or:
       - mnemonic: sha256rnds2 = Perform Two Rounds of SHA256 Operation

--- a/nursery/inspect-load-icon-resource.yml
+++ b/nursery/inspect-load-icon-resource.yml
@@ -7,6 +7,7 @@ rule:
       - michael.hunhoff@mandiant.com
     scopes:
       static: basic block
+      dynamic: unspecified   # rule hasn't been upgraded yet
   features:
     # check if call to LoadIcon fails when first argument is NULL
     # and second argument is not a valid predefined icon - LoadIcon

--- a/nursery/manipulate-unmanaged-memory-in-dotnet.yml
+++ b/nursery/manipulate-unmanaged-memory-in-dotnet.yml
@@ -6,6 +6,7 @@ rule:
       - michael.hunhoff@mandiant.com
     scopes:
       static: function
+      dynamic: unspecified   # rule hasn't been migrated yet
   features:
     - or:
       - class: System.Runtime.InteropServices.Marshal

--- a/nursery/mixed-mode.yml
+++ b/nursery/mixed-mode.yml
@@ -7,6 +7,7 @@ rule:
     description: file contains managed and unmanaged (native) code, often seen in .NET
     scopes:
       static: file
+      dynamic: unspecified
   features:
     - or:
       - characteristic: mixed mode

--- a/nursery/save-image-in-dotnet.yml
+++ b/nursery/save-image-in-dotnet.yml
@@ -6,6 +6,7 @@ rule:
       - michael.hunhoff@mandiant.com
     scopes:
       static: function
+      dynamic: unspecified   # rule hasn't been migrated yet
   features:
     - and:
       - api: System.Drawing.Image::Save

--- a/nursery/search-for-credit-card-data.yml
+++ b/nursery/search-for-credit-card-data.yml
@@ -6,6 +6,7 @@ rule:
       - matthew.williams@mandiant.com
     scopes:
       static: function
+      dynamic: unspecified   # rule hasn't been migrated yet
   features:
     - and:
       - instruction:

--- a/nursery/set-http-user-agent-in-dotnet.yml
+++ b/nursery/set-http-user-agent-in-dotnet.yml
@@ -6,6 +6,7 @@ rule:
       - michael.hunhoff@mandiant.com
     scopes:
       static: function
+      dynamic: unspecified   # rule hasn't been migrated yet
   features:
     - or:
       - property/write: System.Net.HttpWebRequest::UserAgent

--- a/nursery/set-web-proxy-in-dotnet.yml
+++ b/nursery/set-web-proxy-in-dotnet.yml
@@ -6,6 +6,7 @@ rule:
       - michael.hunhoff@mandiant.com
     scopes:
       static: function
+      dynamic: unspecified   # rule hasn't been migrated yet
   features:
     - and:
       - property/write: System.Net.WebRequest::Proxy

--- a/nursery/terminate-process-by-name.yml
+++ b/nursery/terminate-process-by-name.yml
@@ -6,6 +6,7 @@ rule:
       - william.ballenthin@mandiant.com
     scopes:
       static: function
+      dynamic: unspecified   # rule hasn't been migrated yet
   features:
     - and:
       - match: terminate process


### PR DESCRIPTION
This PR adds the `dynamic: scope` to some remaining rules that are missing it.