### PR TITLE
Update generate-random-numbers-via-rtlgenrandom.yml

### DIFF
--- a/data-manipulation/prng/generate-random-numbers-via-rtlgenrandom.yml
+++ b/data-manipulation/prng/generate-random-numbers-via-rtlgenrandom.yml
@@ -23,4 +23,3 @@ rule:
         - optional:
           - string: /advapi32/i
           - string: /cryptsp/i
-          - characteristic: indirect call


### PR DESCRIPTION
this line is already part of `link function at runtime on Windows`

missed in #828
