### PR TITLE
identify .NET single file bundles

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # capa rules
 
 [![Rule linter status](https://github.com/mandiant/capa-rules/workflows/CI/badge.svg)](https://github.com/mandiant/capa-rules/actions?query=workflow%3A%22CI%22)
-[![Number of rules](https://img.shields.io/badge/rules-847-blue.svg)](rules)
+[![Number of rules](https://img.shields.io/badge/rules-848-blue.svg)](rules)
 [![License](https://img.shields.io/badge/license-Apache--2.0-green.svg)](LICENSE.txt)
 
 This is the standard collection of rules for [capa](https://github.com/mandiant/capa) - the tool to automatically identify capabilities of programs.

--- a/bundled-with-dotnet-single-file-deployment.yml
+++ b/bundled-with-dotnet-single-file-deployment.yml
@@ -1,0 +1,19 @@
+rule:
+  meta:
+    name: bundled with .NET single-file deployment
+    namespace: runtime/dotnet
+    authors:
+      - sara.rincon@mandiant.com
+    scope: file
+    references:
+      - https://learn.microsoft.com/en-us/dotnet/core/deploying/single-file/overview?tabs=cli
+      - https://github.com/dotnet/runtime/blob/84de9b678613675e0444b265905c82d33dae33a8/src/installer/managed/Microsoft.NET.HostModel/AppHost/HostWriter.cs
+    examples:
+      - a83339b07cf2bf1aeda192de42760c625d4b2f106260f58c902d02f4766848d5
+  features:
+    - or:
+      - and:
+        - match: contains PDB path
+        - string: "singlefilehost.pdb"
+      - export: DotNetRuntimeInfo
+      - export: corehost_initialize


### PR DESCRIPTION
.NET single file deployments allow all the dependencies to be included in a single binary.  Other capa rules might not be relevant for this single file bundles. Perhaps a warning could be displayed, same as for MSI. Additional information can be found in https://learn.microsoft.com/en-us/dotnet/core/deploying/single-file/overview?tabs=cli
