### PR TITLE
updated rule to detect .NET single file deployment bundles (exe)

### DIFF
--- a/executable/installer/dotnet/bundled-with-dotnet-single-file-deployment.yml
+++ b/executable/installer/dotnet/bundled-with-dotnet-single-file-deployment.yml
@@ -1,0 +1,19 @@
+rule:
+  meta:
+    name: bundled with .NET single-file deployment
+    namespace: executable/installer/dotnet
+    authors:
+      - sara.rincon@mandiant.com
+    scope: file
+    references:
+      - https://learn.microsoft.com/en-us/dotnet/core/deploying/single-file/overview?tabs=cli
+      - https://github.com/dotnet/runtime/blob/84de9b678613675e0444b265905c82d33dae33a8/src/installer/managed/Microsoft.NET.HostModel/AppHost/HostWriter.cs
+    examples:
+      - 0da87fccbf7687a6c7ab38087dea8b8f32c2b1fb6546101485b7167d18d9c406
+  features:
+    - or:
+      - and:
+        - match: contains PDB path
+        - string: "singlefilehost.pdb"
+          description: symbol file for the native executable when PublishSingleFile is true
+      - string: "Detected Single-File app bundle"


### PR DESCRIPTION
In this PR I am not adding another rule to internal/limitation/file cause this one would fall under the installer file limitation category cause it would be in executable/installer/dotnet. There is another rule in there (packaged as single file dotnet application) that seems to target ELF files.
Sample test file is smaller.