### PR TITLE
fix logic after dynamic update

### DIFF
--- a/anti-analysis/anti-vm/vm-detection/check-for-windows-sandbox-via-genuine-state.yml
+++ b/anti-analysis/anti-vm/vm-detection/check-for-windows-sandbox-via-genuine-state.yml
@@ -16,20 +16,22 @@ rule:
     examples:
       - 773290480d5445f11d3dc1b800728966:0x140001140
   features:
-    - and:
-      # static
-      - basic block:
-        - and:
-          - api: SLIsGenuineLocal
-      - basic block:
-        - and:
-          - api: UuidFromString
-          - string: "55c92734-d682-4d71-983e-d6ec3f16059f"
-      # dynamic
-      - call:
-        - and:
-          - api: SLIsGenuineLocal
-      - call:
-        - and:
-          - api: UuidFromString
-          - string: "55c92734-d682-4d71-983e-d6ec3f16059f"
+    - or:
+      - and:
+        # static
+        - basic block:
+          - and:
+            - api: SLIsGenuineLocal
+        - basic block:
+          - and:
+            - api: UuidFromString
+            - string: "55c92734-d682-4d71-983e-d6ec3f16059f"
+      - and:
+        # dynamic
+        - call:
+          - and:
+            - api: SLIsGenuineLocal
+        - call:
+          - and:
+            - api: UuidFromString
+            - string: "55c92734-d682-4d71-983e-d6ec3f16059f"

--- a/communication/socket/create-vmci-socket.yml
+++ b/communication/socket/create-vmci-socket.yml
@@ -5,25 +5,27 @@ rule:
     authors:
       - jakub.jozwiak@mandiant.com
     scopes:
-      static: function
+      static: basic block
       dynamic: thread
     mbc:
       - Communication::Socket Communication::Create Socket [C0001.003]
     references:
       - https://www.vmware.com/products/beta/ws/VMCIsockets.pdf
     examples:
-      - 9ed5660c6a442dbba9e2ba795ccc913c1f1517ce89854fe4287c1c8b36b21d52:0x180001241
+      - 9ed5660c6a442dbba9e2ba795ccc913c1f1517ce89854fe4287c1c8b36b21d52:0x1800011D0
   features:
     - or:
       - and:
         - os: windows
-        - api: DeviceIoControl
-        - number: 0x81032068 = VMCI_SOCKETS_GET_AF_VALUE
-        - optional:
+        - or:
           - api: socket
+          - api: DeviceIoControl
+        - number: 0x81032068 = VMCI_SOCKETS_GET_AF_VALUE
       - and:
         - os: linux
-        - api: ioctl
-        - number: 0x7B8 = VMCI_SOCKETS_GET_AF_VALUE
+        - call:
+          - and:
+            - api: ioctl
+            - number: 0x7B8 = VMCI_SOCKETS_GET_AF_VALUE
         - optional:
           - api: socket

--- a/communication/socket/create-vmci-socket.yml
+++ b/communication/socket/create-vmci-socket.yml
@@ -23,9 +23,7 @@ rule:
         - number: 0x81032068 = VMCI_SOCKETS_GET_AF_VALUE
       - and:
         - os: linux
-        - call:
-          - and:
-            - api: ioctl
-            - number: 0x7B8 = VMCI_SOCKETS_GET_AF_VALUE
-        - optional:
+        - or:
+          - api: ioctl
           - api: socket
+        - number: 0x7B8 = VMCI_SOCKETS_GET_AF_VALUE

--- a/host-interaction/file-system/read/read-file-via-mapping.yml
+++ b/host-interaction/file-system/read/read-file-via-mapping.yml
@@ -12,38 +12,40 @@ rule:
     examples:
       - Practical Malware Analysis Lab 01-01.exe_:0x401440
   features:
-    - and:
-      # static
-      - basic block:
-        - and:
-          - api: kernel32.MapViewOfFile
-          - or:
-            - number: 4 = FILE_MAP_READ
-            - number: 6 = FILE_MAP_WRITE | FILE_MAP_READ
-      - optional:
-        - api: kernel32.UnmapViewOfFile
-        - and:
-          - match: get file size
+    - or:
+      - and:
+        # static
         - basic block:
           - and:
-            - api: kernel32.CreateFileMapping
+            - api: kernel32.MapViewOfFile
             - or:
-              - number: 2 = PAGE_READONLY
-              - number: 4 = PAGE_READWRITE
-      # dynamic
-      - call:
-        - and:
-          - api: kernel32.MapViewOfFile
-          - or:
-            - number: 4 = FILE_MAP_READ
-            - number: 6 = FILE_MAP_WRITE | FILE_MAP_READ
-      - optional:
-        - api: kernel32.UnmapViewOfFile
-        - and:
-          - match: get file size
+              - number: 4 = FILE_MAP_READ
+              - number: 6 = FILE_MAP_WRITE | FILE_MAP_READ
+        - optional:
+          - api: kernel32.UnmapViewOfFile
+          - and:
+            - match: get file size
+          - basic block:
+            - and:
+              - api: kernel32.CreateFileMapping
+              - or:
+                - number: 2 = PAGE_READONLY
+                - number: 4 = PAGE_READWRITE
+      - and:
+        # dynamic
         - call:
           - and:
-            - api: kernel32.CreateFileMapping
+            - api: kernel32.MapViewOfFile
             - or:
-              - number: 2 = PAGE_READONLY
-              - number: 4 = PAGE_READWRITE
+              - number: 4 = FILE_MAP_READ
+              - number: 6 = FILE_MAP_WRITE | FILE_MAP_READ
+        - optional:
+          - api: kernel32.UnmapViewOfFile
+          - and:
+            - match: get file size
+          - call:
+            - and:
+              - api: kernel32.CreateFileMapping
+              - or:
+                - number: 2 = PAGE_READONLY
+                - number: 4 = PAGE_READWRITE


### PR DESCRIPTION
fixes for #855

when generating subscope rules (in the format of rule/uuid) we emit subrules at all scopes, when matching in static flavor this includes dynamic subscopes which can never be matched if static and dynamic are both required, so e.g. `file-system/read/read-file-via-mapping.yml` before this update could not match.

https://github.com/mandiant/capa/blob/51ddadbc87b113dda18495b49e490f8452292b87/capa/rules/__init__.py#L925-L928

@yelhamer is this intended behavior or a bug? I think our current documentation calls this out differently (and I assumed it works differently since I created these faulty rules in the first place 😄 )