### PR TITLE
Fix the dynamic flavor scope for allocate-or-change-rw-memory.yml

### DIFF
--- a/lib/allocate-memory.yml
+++ b/lib/allocate-memory.yml
@@ -7,7 +7,7 @@ rule:
     lib: true
     scopes:
       static: basic block
-      dynamic: thread
+      dynamic: call
     mbc:
       - Memory::Allocate Memory [C0007]
     examples:

--- a/lib/allocate-or-change-rw-memory.yml
+++ b/lib/allocate-or-change-rw-memory.yml
@@ -7,7 +7,7 @@ rule:
     lib: true
     scopes:
       static: basic block
-      dynamic: thread
+      dynamic: call
     mbc:
       - Memory::Allocate Memory [C0007]
     examples:

--- a/lib/change-memory-protection.yml
+++ b/lib/change-memory-protection.yml
@@ -6,7 +6,7 @@ rule:
     lib: true
     scopes:
       static: basic block
-      dynamic: thread
+      dynamic: call
     mbc:
       - Memory::Change Memory Protection [C0008]
     examples:


### PR DESCRIPTION
As mentioned by @mike-hunhoff , the rule in its current format can match if the `number: 0x4 = PAGE_READWRITE` feature is present in another call in the same thread. Setting the rule's dynamic scope to `call` helps prevent this.


<!--
Thank you for contributing to capa! <3

Please ensure that:
1. each rule passes thorough linting (in rules directory: `python ../scripts/lint.py --thorough -t "<your rule name>" -v .`)
2. you've uploaded each referenced example binary (optional, but greatly appreciated) to https://github.com/fireeye/capa-testfiles

Please mention the issue your PR addresses (if any):
closes #issue_number
-->
