### PR TITLE
Update reference-analysis-tools-strings.yml

### DIFF
--- a/anti-analysis/reference-analysis-tools-strings.yml
+++ b/anti-analysis/reference-analysis-tools-strings.yml
@@ -24,8 +24,8 @@ rule:
       - string: /procmon(\.exe)?/i
       - string: /regmon(\.exe)?/i
       - string: /procexp(\.exe)?/i
-      - string: /ida[gqtuw]?(\.exe)?$/i
-      - string: /ida[gqtuw]64(\.exe)?$/i
+      - string: /(?<!\w)ida[gqtuw]?(\.exe)?$/i
+      - string: /ida[gqtuw]?64(\.exe)?$/i
       - string: /ImmunityDebugger(\.exe)?/i
       - string: /Wireshark(\.exe)?/i
       - string: /dumpcap(\.exe)?/i


### PR DESCRIPTION
fix 2 problems:

1. fix false positive by not hitting, if there was a word character before `ida`:
```
regex: /ida[gqtuw]?(\.exe)?$/i
- "@.didat" @ file+0x2F7

405d4c2ef7419bf265edef0fe86c8ba1ed634b10dccaaa0a6c6b953645598619
```

2. regex didn't match ida64.exe because it required one of the characters in the brackets.


<!--
Thank you for contributing to capa! <3

Please ensure that:
1. each rule passes thorough linting (in rules directory: `python ../scripts/lint.py --thorough -t "<your rule name>" -v .`)
2. you've uploaded each referenced example binary (optional, but greatly appreciated) to https://github.com/fireeye/capa-testfiles

Please mention the issue your PR addresses (if any):
closes #issue_number
-->
