### PR TITLE
[CI] Update GitHub actions to versions using Node 20

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,6 @@ jobs:
     - name: Get release text
       run: python .github/scripts/create_releases.py ${{ github.ref_name }} > release_body.txt
     - name: Create GitHub release
-      uses: ncipollo/release-action@v1.12.0
+      uses: ncipollo/release-action@2c591bcc8ecdcd2db72b97d6147f871fcd833ba5 # v1.14.0
       with:
         bodyFile: release_body.txt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       contents: write
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:
         # get all history and tags
         fetch-depth: 0

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -51,7 +51,7 @@ jobs:
       id: files
       uses: Ana06/get-changed-files@v2.2.0
     - name: Set up Python 3.9
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0
       with:
         python-version: 3.9
     - name: Install Python dependencies

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - name: Checkout capa-rules
-      uses: actions/checkout@v3
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
     - name: Count rules
       run: |
         num_rules=$(find . -type f -name '*.yml' -not -path './.github/*' | wc -l)
@@ -29,12 +29,12 @@ jobs:
     # Do not checkout submodules as we don't need capa-testfiles and we need to
     # update the rules submodule reference
     - name: Checkout capa
-      uses: actions/checkout@v3
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:
         repository: mandiant/capa
         token: ${{ secrets.CAPA_TOKEN }}
     - name: Checkout capa-rules
-      uses: actions/checkout@v3
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:
         # To include the commit from update_num_rules (the default `ref` is the
         # one which triggered the action)

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -49,7 +49,7 @@ jobs:
         sed -ir "0,/### New Rules.*/s//### New Rules \($rules\)/" CHANGELOG.md
     - name: Get modified files
       id: files
-      uses: Ana06/get-changed-files@v2.2.0
+      uses: Ana06/get-changed-files@25f79e676e7ea1868813e21465014798211fad8c # v2.3.0
     - name: Set up Python 3.9
       uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0
       with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,7 +44,7 @@ jobs:
         path: tests/data
     # use latest available python for best performance
     - name: Set up Python 3.11
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0
       with:
         python-version: 3.11
     - name: Install capa

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,7 +56,7 @@ jobs:
     - name: Get modified files
       if: github.event_name != 'workflow_dispatch' && github.event_name != 'schedule'
       id: files
-      uses: Ana06/get-changed-files@v2.2.0
+      uses: Ana06/get-changed-files@25f79e676e7ea1868813e21465014798211fad8c # v2.3.0
       # this Action may throw the below error, e.g. when not properly rebased
       # however, it still gets the modified files and we can continue
       # Error: The head commit for this pull_request event is not ahead of the base commit.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,15 +30,15 @@ jobs:
     steps:
     # We check the submodules separately as the rules submodule's reference may not be our PR/master
     - name: Checkout capa without submodules
-      uses: actions/checkout@v3
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:
         repository: mandiant/capa
     - name: Checkout capa-rules
-      uses: actions/checkout@v3
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:
         path: rules
     - name: Checkout capa-testfiles
-      uses: actions/checkout@v3
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:
         repository: mandiant/capa-testfiles
         path: tests/data
@@ -108,12 +108,12 @@ jobs:
         echo "zip_name=capa-$v-linux.zip" >> $GITHUB_ENV
         echo "major_version=$(echo $v | cut -d. -f1)" >> $GITHUB_ENV
     - name: Checkout capa-rules
-      uses: actions/checkout@v3
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:
         ref: ${{ env.major_version }}
         path: rules
     - name: Checkout capa-testfiles
-      uses: actions/checkout@v3
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:
         repository: mandiant/capa-testfiles
         path: tests/data


### PR DESCRIPTION
Update all actions using a deprecated version of Node: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20