### PR TITLE
Create encrypt-data-using-rc4-via-systemfunction033.yml

### DIFF
--- a/data-manipulation/encryption/rc4/encrypt-data-using-rc4-via-systemfunction033.yml
+++ b/data-manipulation/encryption/rc4/encrypt-data-using-rc4-via-systemfunction033.yml
@@ -1,6 +1,6 @@
 rule:
   meta:
-    name: encryptdecrypt-data-using-rc4-via-systemfunction033.yml
+    name: encrypt data using RC4 via SystemFunction033
     namespace: data-manipulation/encryption/rc4
     authors:
       - daniel.stepanic@elastic.co

--- a/data-manipulation/encryption/rc4/encrypt-data-using-rc4-via-systemfunction033.yml
+++ b/data-manipulation/encryption/rc4/encrypt-data-using-rc4-via-systemfunction033.yml
@@ -1,0 +1,27 @@
+rule:
+  meta:
+    name: encrypt/decrypt data using RC4 via SystemFunction033
+    namespace: data-manipulation/encryption/rc4
+    authors:
+      - daniel.stepanic@elastic.co
+    scopes:
+      static: function
+      dynamic: thread
+    att&ck:
+      - Defense Evasion::Obfuscated Files or Information [T1027]
+    mbc:
+      - Defense Evasion::Obfuscated Files or Information::Encryption-Standard Algorithm [E1027.m05]
+      - Cryptography::Encrypt Data::RC4 [C0027.009]
+    references:
+      - https://www.redteam.cafe/red-team/shellcode-injection/inmemory-shellcode-encryption-and-decryption-using-systemfunction033
+    examples:
+      - 0f33c2fec223823f84a732ceb1ad94ed2645e896095144850cf1443aeda67da6:0x180001000 # api match
+  features:
+    - or:
+      - api: SystemFunction033
+      - and:
+        - match: link function at runtime on Windows
+        - string: "SystemFunction033"
+        - optional:
+          - string: /advapi32/i
+          - string: /cryptsp/i

--- a/data-manipulation/encryption/rc4/encrypt-data-using-rc4-via-systemfunction033.yml
+++ b/data-manipulation/encryption/rc4/encrypt-data-using-rc4-via-systemfunction033.yml
@@ -1,6 +1,6 @@
 rule:
   meta:
-    name: encrypt/decrypt data using RC4 via SystemFunction033
+    name: encryptdecrypt-data-using-rc4-via-systemfunction033.yml
     namespace: data-manipulation/encryption/rc4
     authors:
       - daniel.stepanic@elastic.co


### PR DESCRIPTION
Hi,

This rule is pretty much a duplicate of the existing rule ([SystemFunction032](https://github.com/mandiant/capa-rules/blob/master/data-manipulation/encryption/rc4/encrypt-data-using-rc4-via-systemfunction032.yml)), it's paired with another undocumented API (`SystemFunction033`) that implements encryption/decryption using RC4 algorithm. Thanks!

**References**
- [0f33c2fec223823f84a732ceb1ad94ed2645e896095144850cf1443aeda67da6](https://www.virustotal.com/gui/file/0f33c2fec223823f84a732ceb1ad94ed2645e896095144850cf1443aeda67da6)
- https://www.blackhillsinfosec.com/avoiding-memory-scanners/

<!--
Thank you for contributing to capa! <3

Please ensure that:
1. each rule passes thorough linting (in rules directory: `python ../scripts/lint.py --thorough -t "<your rule name>" -v .`)
2. you've uploaded each referenced example binary (optional, but greatly appreciated) to https://github.com/fireeye/capa-testfiles

Please mention the issue your PR addresses (if any):
closes #issue_number
-->
