### PR TITLE
reduce FPs by adjusting `go1.` substring feature

### DIFF
--- a/compiler/go/compiled-with-go.yml
+++ b/compiler/go/compiled-with-go.yml
@@ -14,7 +14,7 @@ rule:
       - string: /^Go build ID:/
       - substring: "go.buildid"
       - string: /^Go buildinf:/
-      - substring: "go1."
+      - string: /go1.\d+./
       - substring: "runtime.main"
       - substring: "main.main"
       - substring: "runtime.gcWork"

--- a/compiler/go/compiled-with-go.yml
+++ b/compiler/go/compiled-with-go.yml
@@ -14,7 +14,7 @@ rule:
       - string: /^Go build ID:/
       - substring: "go.buildid"
       - string: /^Go buildinf:/
-      - string: /go1.\d+./
+      - string: /go1.\d+/
       - substring: "runtime.main"
       - substring: "main.main"
       - substring: "runtime.gcWork"

--- a/compiler/go/compiled-with-go.yml
+++ b/compiler/go/compiled-with-go.yml
@@ -14,7 +14,7 @@ rule:
       - string: /^Go build ID:/
       - substring: "go.buildid"
       - string: /^Go buildinf:/
-      - string: /go1.\d+/
+      - string: /\bgo1\.\d/
       - substring: "runtime.main"
       - substring: "main.main"
       - substring: "runtime.gcWork"


### PR DESCRIPTION
`go1.` would for example match on `logo1.jpg`
