### PR TITLE
add API features for ws2_32 ordinals

### DIFF
--- a/communication/dns/resolve-dns.yml
+++ b/communication/dns/resolve-dns.yml
@@ -16,16 +16,19 @@ rule:
       - 17264e3126a97c319a6a0c61e6da951e:0x5FDC25D0
   features:
     - or:
+      - api: gethostbyname
       - api: ws2_32.gethostbyname
+      - api: ws2_32.#52 = gethostbyname
       - api: DnsQuery_A
       - api: DnsQuery_W
       - api: DnsQuery_UTF8
       - api: DnsQueryEx
-      - api: getaddrinfo
       - api: GetAddrInfo
+      - api: ws2_32.#24 = GetAddrInfoW
       - api: GetAddrInfoEx
-      - api: gethostbyname
       - api: getaddrinfo
+      - api: ws2_32.#98 = getaddrinfo
       - api: getnameinfo
+      - api: ws2_32.#99 = getnameinfo
       - api: gethostent
       - api: System.Net.Dns::GetHostAddresses

--- a/communication/socket/create-raw-socket.yml
+++ b/communication/socket/create-raw-socket.yml
@@ -20,7 +20,10 @@ rule:
     - and:
       - or:
         - api: socket
-        - api: ws2_32.WSASocketA
+        - api: ws2_32.#23 = socket
+        - api: ws2_32.WSASocket
+        - api: ws2_32.#82 = WSASocketA
+        - api: ws2_32.#83 = WSASocketW
       - or:
         - number: 2 = AF_INET
         - number: 23 = AF_INET6

--- a/communication/socket/get-socket-status.yml
+++ b/communication/socket/get-socket-status.yml
@@ -14,5 +14,6 @@ rule:
     examples:
       - 6A352C3E55E8AE5ED39DC1BE7FB964B1:0x1000C1F0
   features:
-    - and:
+    - or:
       - api: ws2_32.select
+      - api: ws2_32.#18 = select

--- a/communication/socket/initialize-winsock-library.yml
+++ b/communication/socket/initialize-winsock-library.yml
@@ -12,5 +12,6 @@ rule:
     examples:
       - 6A352C3E55E8AE5ED39DC1BE7FB964B1:0x10001D30
   features:
-    - and:
+    - or:
       - api: ws2_32.WSAStartup
+      - api: ws2_32.#115 = WSAStartup

--- a/communication/socket/receive/receive-data-on-socket.yml
+++ b/communication/socket/receive/receive-data-on-socket.yml
@@ -15,14 +15,20 @@ rule:
       - Practical Malware Analysis Lab 01-01.dll_:0x10001010
   features:
     - or:
+      - api: recv
       - api: ws2_32.recv
+      - api: ws2_32.#16 = recv
       - api: ws2_32.recvfrom
+      - api: ws2_32.#17 = recvfrom
       - api: ws2_32.WSARecv
+      - api: ws2_32.#71 = WSARecv
       - api: ws2_32.WSARecvDisconnect
+      - api: ws2_32.#72 = WSARecvDisconnect
       - api: ws2_32.WSARecvEx
       - api: ws2_32.WSARecvFrom
+      - api: ws2_32.#73 = WSARecvFrom
       - api: ws2_32.WSARecvMsg
-      - api: recv
+      - api: recvmsg
       - api: System.Net.Sockets.Socket::Receive
       - api: System.Net.Sockets.Socket::ReceiveAsync
       - api: System.Net.Sockets.Socket::ReceiveFrom
@@ -35,4 +41,3 @@ rule:
       - api: System.Net.Sockets.Socket::EndReceive
       - api: System.Net.Sockets.Socket::EndReceiveFrom
       - api: System.Net.Sockets.Socket::EndReceiveMessageFrom
-      - api: recvmsg

--- a/communication/socket/send/send-data-on-socket.yml
+++ b/communication/socket/send/send-data-on-socket.yml
@@ -15,12 +15,16 @@ rule:
       - Practical Malware Analysis Lab 01-01.dll_:0x10001010
   features:
     - or:
+      - api: send
       - api: ws2_32.send
+      - api: ws2_32.#19 = send
       - api: ws2_32.sendto
+      - api: ws2_32.#20 = sendto
       - api: ws2_32.WSASend
+      - api: ws2_32.#76 = WSASend
       - api: ws2_32.WSASendMsg
       - api: ws2_32.WSASendTo
-      - api: send
+      - api: ws2_32.#78 = WSASendTo
       - api: System.Net.Sockets.Socket::Send
       - api: System.Net.Sockets.Socket::SendAsync
       - api: System.Net.Sockets.Socket::SendTo

--- a/communication/socket/set-socket-configuration.yml
+++ b/communication/socket/set-socket-configuration.yml
@@ -14,4 +14,6 @@ rule:
   features:
     - or:
       - api: ws2_32.setsockopt
+      - api: ws2_32.#21 = setsockopt
       - api: ws2_32.ioctlsocket
+      - api: ws2_32.#10 = ioctlsocket

--- a/communication/socket/tcp/connect-tcp-socket.yml
+++ b/communication/socket/tcp/connect-tcp-socket.yml
@@ -18,7 +18,9 @@ rule:
       - or:
         - api: connect
         - api: ws2_32.connect
+        - api: ws2_32.#4 = connect
         - api: ws2_32.WSAConnect
+        - api: ws2_32.#33 = WSAConnect
         - api: ConnectEx
         - or:
           - and:
@@ -32,27 +34,39 @@ rule:
                 - number: 0x3E06748C
             - basic block:
               - and:
-                - api: WSAIoctl
+                - or:
+                  - api: ws2_32.WSAIoctl
+                  - api: ws2_32.#60 = WSAIoctl
                 - number: 0xC8000006 = SIO_GET_EXTENSION_FUNCTION_POINTER
             - basic block:
               - and:
-                - api: setsockopt
+                - or:
+                  - api: setsockopt
+                  - api: ws2_32.#21 = setsockopt
                 - number: 0xFFFF = SOL_SOCKET
                 - number: 0x7010 = SO_UPDATE_CONNECT_CONTEXT
             # socket must be bound to ConnectEx
             # https://gist.github.com/joeyadams/4158972
-            - api: bind
+            - or:
+              - api: bind
+              - api: ws2_32.#2 = bind
           - and:
             # dynamic
             - call:
               - and:
-                - api: WSAIoctl
+                - or:
+                  - api: ws2_32.WSAIoctl
+                  - api: ws2_32.#60 = WSAIoctl
                 - number: 0xC8000006 = SIO_GET_EXTENSION_FUNCTION_POINTER
             - call:
               - and:
-                - api: setsockopt
+                - or:
+                  - api: setsockopt
+                  - api: ws2_32.#21 = setsockopt
                 - number: 0xFFFF = SOL_SOCKET
                 - number: 0x7010 = SO_UPDATE_CONNECT_CONTEXT
             # socket must be bound to ConnectEx
             # https://gist.github.com/joeyadams/4158972
-            - api: bind
+            - or:
+              - api: bind
+              - api: ws2_32.#2 = bind

--- a/communication/socket/tcp/create-tcp-socket.yml
+++ b/communication/socket/tcp/create-tcp-socket.yml
@@ -21,8 +21,11 @@ rule:
         - number: 1 = SOCK_STREAM
         - number: 2 = AF_INET
         - or:
-          - api: ws2_32.socket
-          - api: ws2_32.WSASocket
           - api: socket
+          - api: ws2_32.socket
+          - api: ws2_32.#23 = socket
+          - api: ws2_32.WSASocket
+          - api: ws2_32.#82 = WSASocketA
+          - api: ws2_32.#83 = WSASocketW
           - api: System.Net.Sockets.Socket::ctor
       - property/read: System.Net.Sockets.TcpClient::Client

--- a/communication/socket/udp/send/create-udp-socket.yml
+++ b/communication/socket/udp/send/create-udp-socket.yml
@@ -18,8 +18,11 @@ rule:
       - and:
         - count(number(2 = AF_INET/SOCK_DGRAM)): 2 or more
         - or:
-          - api: ws2_32.socket
-          - api: ws2_32.WSASocket
           - api: socket
+          - api: ws2_32.socket
+          - api: ws2_32.#23 = socket
+          - api: ws2_32.WSASocket
+          - api: ws2_32.#82 = WSASocketA
+          - api: ws2_32.#83 = WSASocketW
           - api: System.Net.Sockets.Socket::ctor
       - api: System.Net.Sockets.UdpClient::ctor

--- a/nursery/get-socket-information.yml
+++ b/nursery/get-socket-information.yml
@@ -10,5 +10,6 @@ rule:
     att&ck:
       - Discovery::System Network Configuration Discovery [T1016]
   features:
-    - and:
+    - or:
       - api: ws2_32.getsockname
+      - api: ws2_32.#6 = getsockname


### PR DESCRIPTION
Programs can import networking routines from ws2_32 by ordinal, and this is occasionally seen in the while, such as in PMA 01-01.dll.

This file shows an example of mapping ordinals to names for ws2_32: https://github.com/phracker/HopperScripts/blob/9468cdadb2c139d474662ae82716a5098e7350e4/WS2_32.dll%20Ordinals%20to%20Names.py#L8

Today, we rely on vivisect (or the binary analysis backend) to resolve ordinal numbers to human-readable names; however, not all analysis backends may have this mapping. So, we can extend our rules to also match these ordinals.

For example, with these changes using a backend that doesn't support ordinal mapping:

![image](https://github.com/mandiant/capa-rules/assets/156560/7773ab64-ebdd-4d8a-a1f0-600022431bfb)
