### PR TITLE
Create self-delete-using-alternate-data-streams.yml

### DIFF
--- a/anti-analysis/anti-forensic/self-deletion/self-delete-using-alternate-data-streams.yml
+++ b/anti-analysis/anti-forensic/self-deletion/self-delete-using-alternate-data-streams.yml
@@ -1,0 +1,52 @@
+rule:
+  meta:
+    name: self delete using alternate data streams
+    namespace: anti-analysis/anti-forensic/self-deletion
+    authors:
+      - daniel.stepanic@elastic.co
+    scopes:
+      static: function
+      dynamic: thread
+    att&ck:
+      - Defense Evasion::Indicator Removal::File Deletion [T1070.004]
+    mbc:
+      - Defense Evasion::Self Deletion [F0007]
+    references:
+      - https://github.com/LloydLabs/delete-self-poc
+    examples:
+      - c2d46d256b8f9490c9599eea11ecef19fde7d4fdd2dea93604cee3cea8e172ac:0x1400019C0
+      - 388021747b85453adff2680c8a0e13e230f4eeada1a1055e3fb8e09800d4fb79:0x180003A24
+  features:
+    - or:
+      - and:
+        - count(api(kernel32.SetFileInformationByHandle)): 2
+        - and:
+          - basic block:
+            - and:
+              - api: kernel32.SetFileInformationByHandle
+              - number: 4 = FileDispositionInfo
+              - number: 1 = BufferSize
+        - and:
+          - basic block:
+            - and:
+              - api: kernel32.SetFileInformationByHandle
+              - number: 3 = FileRenameInfo
+        - and:
+          - count(api(kernel32.CreateFile)): 2
+          - number: 0x10000 = DELETE
+      - and:
+        - count(api(kernel32.SetFileInformationByHandle)): 2
+        - and:
+          - instruction:
+            - mnemonic: lea
+            - offset: 0x4 = FileDispositionInfo
+          - and:
+            - mnemonic: lea
+            - offset: 0x1 = BufferSize
+        - and:
+          - count(api(kernel32.CreateFile)): 2
+          - number: 0x10000 = DELETE
+        - and:
+          - instruction:
+            - mnemonic: lea
+            - offset: -0x1D

--- a/anti-analysis/anti-forensic/self-deletion/self-delete-using-alternate-data-streams.yml
+++ b/anti-analysis/anti-forensic/self-deletion/self-delete-using-alternate-data-streams.yml
@@ -19,16 +19,27 @@ rule:
   features:
     - and:
       - count(api(kernel32.SetFileInformationByHandle)): 2
-      - basic block:
-        - and:
-          - api: kernel32.SetFileInformationByHandle
-          - optional:
+      - or:
+        - basic block:
+          - and:
+            - api: kernel32.SetFileInformationByHandle
+            - optional:
+              - number: 3 = FileRenameInfo
+        - call:
+          - and:
+            - api: SetFileInformationByHandle
             - number: 3 = FileRenameInfo
-      - basic block:
-        - and:
-          - api: kernel32.SetFileInformationByHandle
-          - number: 4 = FileDispositionInfo
-          - number: 1 = TRUE // fDelete.DeleteFile = TRUE;
+      - or:
+        - basic block:
+          - and:
+            - api: kernel32.SetFileInformationByHandle
+            - number: 4 = FileDispositionInfo
+            - number: 1 = TRUE // fDelete.DeleteFile = TRUE;
+        - call:
+          - and:
+            - api: SetFileInformationByHandle
+            - number: 4 = FileDispositionInfo
+            - number: 1 = TRUE // fDelete.DeleteFile = TRUE;
       - and:
         - count(api(kernel32.CreateFile)): 2
         - number: 0x10000 = DELETE

--- a/anti-analysis/anti-forensic/self-deletion/self-delete-using-alternate-data-streams.yml
+++ b/anti-analysis/anti-forensic/self-deletion/self-delete-using-alternate-data-streams.yml
@@ -17,37 +17,18 @@ rule:
       - c2d46d256b8f9490c9599eea11ecef19fde7d4fdd2dea93604cee3cea8e172ac:0x1400019C0
       - 388021747b85453adff2680c8a0e13e230f4eeada1a1055e3fb8e09800d4fb79:0x180003A24
   features:
-    - or:
+    - and:
+      - count(api(kernel32.SetFileInformationByHandle)): 2
+      - basic block:
+        - and:
+          - api: kernel32.SetFileInformationByHandle
+          - optional:
+            - number: 3 = FileRenameInfo
+      - basic block:
+        - and:
+          - api: kernel32.SetFileInformationByHandle
+          - number: 4 = FileDispositionInfo
+          - number: 1 = TRUE // fDelete.DeleteFile = TRUE;
       - and:
-        - count(api(kernel32.SetFileInformationByHandle)): 2
-        - and:
-          - basic block:
-            - and:
-              - api: kernel32.SetFileInformationByHandle
-              - number: 4 = FileDispositionInfo
-              - number: 1 = BufferSize
-        - and:
-          - basic block:
-            - and:
-              - api: kernel32.SetFileInformationByHandle
-              - number: 3 = FileRenameInfo
-        - and:
-          - count(api(kernel32.CreateFile)): 2
-          - number: 0x10000 = DELETE
-      - and:
-        - count(api(kernel32.SetFileInformationByHandle)): 2
-        - and:
-          - instruction:
-            - mnemonic: lea
-            - offset: 0x4 = FileDispositionInfo
-          - and:
-            - mnemonic: lea
-            - offset: 0x1 = BufferSize
-        - and:
-          - count(api(kernel32.CreateFile)): 2
-          - number: 0x10000 = DELETE
-        - and:
-          - instruction:
-            - description: Uses arithmetic to return FILE_INFORMATION_CLASS (FileRenameInfo)
-            - mnemonic: lea
-            - offset: -0x1D
+        - count(api(kernel32.CreateFile)): 2
+        - number: 0x10000 = DELETE

--- a/anti-analysis/anti-forensic/self-deletion/self-delete-using-alternate-data-streams.yml
+++ b/anti-analysis/anti-forensic/self-deletion/self-delete-using-alternate-data-streams.yml
@@ -48,5 +48,6 @@ rule:
           - number: 0x10000 = DELETE
         - and:
           - instruction:
+            - description: Uses arithmetic to return FILE_INFORMATION_CLASS (FileRenameInfo)          
             - mnemonic: lea
             - offset: -0x1D

--- a/anti-analysis/anti-forensic/self-deletion/self-delete-using-alternate-data-streams.yml
+++ b/anti-analysis/anti-forensic/self-deletion/self-delete-using-alternate-data-streams.yml
@@ -48,6 +48,6 @@ rule:
           - number: 0x10000 = DELETE
         - and:
           - instruction:
-            - description: Uses arithmetic to return FILE_INFORMATION_CLASS (FileRenameInfo)          
+            - description: Uses arithmetic to return FILE_INFORMATION_CLASS (FileRenameInfo)
             - mnemonic: lea
             - offset: -0x1D


### PR DESCRIPTION
Reference: #894
Test data: https://github.com/mandiant/capa-testfiles/pull/231

Adding capa rule for self-deletion technique. I tried to capture the main behaviors in the rule across two implementations. I am open for suggestions or improvements to the rule. Thanks in advance!

