### PR TITLE
Update encrypt-data-using-dpapi.yml rule

### DIFF
--- a/data-manipulation/encryption/dpapi/encrypt-data-using-dpapi.yml
+++ b/data-manipulation/encryption/dpapi/encrypt-data-using-dpapi.yml
@@ -27,5 +27,9 @@ rule:
       - and:
         - match: link function at runtime on Windows
         - or:
+          # RtlEncryptMemory is available as SystemFunction040 export in Advapi32.dll
+          # CryptProtectMemory is a wrapper function for SystemFunction040
           - string: "SystemFunction040"
+          # RtlDecryptMemory is available as SystemFunction041 export in Advapi32.dll
+          # CryptUnprotectMemory is a wrapper function for SystemFunction041
           - string: "SystemFunction041"

--- a/data-manipulation/encryption/dpapi/encrypt-data-using-dpapi.yml
+++ b/data-manipulation/encryption/dpapi/encrypt-data-using-dpapi.yml
@@ -22,3 +22,10 @@ rule:
       - api: crypt32.CryptUnprotectData
       - api: System.Security.Cryptography.ProtectedData::Unprotect
       - api: System.Security.Cryptography.ProtectedData::Protect
+      - api: SystemFunction040
+      - api: SystemFunction041
+      - and:
+        - match: link function at runtime on Windows
+        - or:
+          - string: "SystemFunction040"
+          - string: "SystemFunction041"


### PR DESCRIPTION
Update encrypt-data-using-dpapi.yml rule - add `RtlEncryptMemory`/`SystemFunction040` and `RtlDecryptMemory`/`SystemFunction041`.
`CryptProtectMemory` and `CryptUnprotectMemory` are wrappers for `SystemFunction040` and `SystemFunction041` respectively.