### PR TITLE
Add capa rules create-thread-bypass-freeze.yml and check-thread-suspend-count-exceeded.yml to nursery.

### DIFF
--- a/nursery/check-thread-suspend-count-exceeded.yml
+++ b/nursery/check-thread-suspend-count-exceeded.yml
@@ -1,0 +1,27 @@
+rule:
+  meta:
+    name: check thread suspend count exceeded
+    authors:
+      - ervinocampo@google.com
+    scopes:
+      static: file
+      dynamic: unsupported #requires mnemonic feature
+    att&ck:
+      - Defense Evasion::Debugger Evasion [T1622]
+    mbc:
+      - Anti-Behavioral Analysis::Debugger Detection [B0001]
+    references:
+      - https://secret.club/2021/01/04/thread-stuff.html
+      - https://research.checkpoint.com/2023/raspberry-robin-anti-evasion-how-to-exploit-analysis/
+  features:
+    - and:
+      - match: create thread bypass process freeze
+      - function:
+        - and:
+          - or:
+            - api: ntdll.NtSuspendThread
+            - string: "NtSuspendThread"
+          - basic block:
+            - and:
+              - number: 0xc000004a = STATUS_SUSPEND_COUNT_EXCEEDED
+              - mnemonic: cmp

--- a/nursery/create-thread-bypass-freeze.yml
+++ b/nursery/create-thread-bypass-freeze.yml
@@ -1,0 +1,23 @@
+rule:
+  meta:
+    name: create thread bypass process freeze
+    authors:
+      - ervinocampo@google.com
+    scopes:
+      static: basic block
+      dynamic: call
+    att&ck:
+      - Defense Evasion::Debugger Evasion [T1622]
+    mbc:
+      - Anti-Behavioral Analysis::Debugger Evasion [B0002]
+    references:
+      - https://secret.club/2021/01/04/thread-stuff.html
+      - https://research.checkpoint.com/2023/raspberry-robin-anti-evasion-how-to-exploit-analysis/
+      - https://www.pinvoke.dev/ntdll/ntcreatethreadex
+      - https://github.com/winsiderss/systeminformer/blob/master/phnt/include/ntpsapi.h
+  features:
+    - and:
+      - or:
+        - api: ntdll.NtCreateThreadEx
+        - string: "NtCreateThreadEx"
+      - number: 0x40 = Undocumented thread creation flag dubbed as THREAD_CREATE_FLAGS_BYPASS_PROCESS_FREEZE


### PR DESCRIPTION

<!--
Thank you for contributing to capa! <3

Please ensure that:
1. each rule passes thorough linting (in rules directory: `python ../scripts/lint.py --thorough -t "<your rule name>" -v .`)
2. you've uploaded each referenced example binary (optional, but greatly appreciated) to https://github.com/fireeye/capa-testfiles

Please mention the issue your PR addresses (if any):
closes #issue_number
-->

Adding two capa rules - create-thread-bypass-freeze.yml and check-thread-suspend-count-exceeded.yml to the nursery. I did not find any public malware sample exhibiting the technique but I did test it with a basic POC code I created based on the referenced articles.