### PR TITLE
Update HC-128 (variation used in Winnti malware)

### DIFF
--- a/data-manipulation/encryption/hc-128/encrypt-data-using-hc-128-via-wolfssl.yml
+++ b/data-manipulation/encryption/hc-128/encrypt-data-using-hc-128-via-wolfssl.yml
@@ -23,5 +23,9 @@ rule:
       - number: 0x17 = 23 from line 153, tem0 = rotrFixed((ctx->T[(v)]),23);
       - number: 0xA = 10 from line 154, tem1 = rotrFixed((ctx->X[(c)]),10);
       - number: 0x8 = 8 from line 155, tem2 = rotrFixed((ctx->X[(b)]),8);
-      - number: 0x3FC = Compiler optimized size used in ANDs for the 1024 sized buffer
-      - count(mnemonic(rol)): 48
+      - or:
+        - number: 0x3FC = Compiler optimized size used in ANDs for the 1024 sized buffer
+        - number: 0x3FF = 0x3FF from line 105, ctx->counter1024 = (ctx->counter1024 + 16) & 0x3ff;
+      - or:
+        - count(mnemonic(rol)): 48
+        - count(mnemonic(ror)): 48


### PR DESCRIPTION
Tested on a Winnti malware sample as the screenshot attached.
<img width="1068" alt="Screenshot 2024-07-25 at 12 36 49" src="https://github.com/user-attachments/assets/a7b5b3b9-8255-466c-870b-a894edf42011">

