### PR TITLE
Add rule for detecting hiding shutdown actions

### DIFF
--- a/host-interaction/os/hide-shutdown-actions-via-policy.yml
+++ b/host-interaction/os/hide-shutdown-actions-via-policy.yml
@@ -10,7 +10,9 @@ rule:
     att&ck:
       - Defense Evasion::Modify Registry [T1112]
     examples:
-      - a6594d9550d56ddeaac8b3140821e698eefb7163ba29f0119c2ef19beb6040b0
+      - a6594d9550d56ddeaac8b3140821e698eefb7163ba29f0119c2ef19beb6040b0:0x14000b47f
+    references:
+      - https://securelist.com/mallox-ransomware/113529/
   features:
     - and:
       - optional:

--- a/host-interaction/os/hide-shutdown-actions-via-policy.yml
+++ b/host-interaction/os/hide-shutdown-actions-via-policy.yml
@@ -12,18 +12,18 @@ rule:
     examples:
       - a6594d9550d56ddeaac8b3140821e698eefb7163ba29f0119c2ef19beb6040b0
   features:
-      - and:
-        - optional:
-          - match: create or open registry key
-        - or:
-          - and:
-            - string: "/Policies/i"
-            - or:
-              - string: "/ShutdownWithoutLogon/i"
-              - string: "/HidePowerOptions/i"
-          - and:
-            - string: "/PolicyManager/i"
-            - or:
-              - string: "/HideRestart/i"
-              - string: "/HideShutDown/i"
-              - string: "/HideSignOut/i"
+    - and:
+      - optional:
+        - match: create or open registry key
+      - or:
+        - and:
+          - string: "/Policies/i"
+          - or:
+            - string: "/ShutdownWithoutLogon/i"
+            - string: "/HidePowerOptions/i"
+        - and:
+          - string: "/PolicyManager/i"
+          - or:
+            - string: "/HideRestart/i"
+            - string: "/HideShutDown/i"
+            - string: "/HideSignOut/i"

--- a/host-interaction/os/hide-shutdown-actions-via-policy.yml
+++ b/host-interaction/os/hide-shutdown-actions-via-policy.yml
@@ -1,0 +1,29 @@
+rule:
+  meta:
+    name: hide shutdown actions via policy
+    namespace: host-interaction/os
+    authors:
+      - still@teamt5.org
+    scopes:
+      static: function
+      dynamic: call
+    att&ck:
+      - Defense Evasion::Modify Registry [T1112]
+    examples:
+      - a6594d9550d56ddeaac8b3140821e698eefb7163ba29f0119c2ef19beb6040b0
+  features:
+      - and:
+        - optional:
+          - match: create or open registry key
+        - or:
+          - and:
+            - string: "/Policies/i"
+            - or:
+              - string: "/ShutdownWithoutLogon/i"
+              - string: "/HidePowerOptions/i"
+          - and:
+            - string: "/PolicyManager/i"
+            - or:
+              - string: "/HideRestart/i"
+              - string: "/HideShutDown/i"
+              - string: "/HideSignOut/i"

--- a/host-interaction/os/hide-shutdown-actions-via-policy.yml
+++ b/host-interaction/os/hide-shutdown-actions-via-policy.yml
@@ -9,10 +9,10 @@ rule:
       dynamic: call
     att&ck:
       - Defense Evasion::Modify Registry [T1112]
-    examples:
-      - a6594d9550d56ddeaac8b3140821e698eefb7163ba29f0119c2ef19beb6040b0:0x14000b47f
     references:
       - https://securelist.com/mallox-ransomware/113529/
+    examples:
+      - a6594d9550d56ddeaac8b3140821e698eefb7163ba29f0119c2ef19beb6040b0:0x14000b47f
   features:
     - and:
       - optional:


### PR DESCRIPTION
<!--
Thank you for contributing to capa! <3

Please ensure that:
1. each rule passes thorough linting (in rules directory: `python ../scripts/lint.py --thorough -t "<your rule name>" -v .`)
2. you've uploaded each referenced example binary (optional, but greatly appreciated) to https://github.com/fireeye/capa-testfiles

Please mention the issue your PR addresses (if any):
closes #issue_number
-->


## Summary

This PR adds a rule that detects registry values related to hiding shutdown actions (i.e., logout, shutdown, reboot, etc.), specifically ones using policy registry values. This is often abused by ransomware to prevent mid-encryption-shutdowns. 