### PR TITLE
update analogous to capa repo, removing Python 3.8

### DIFF
--- a/.github/scripts/create_releases.py
+++ b/.github/scripts/create_releases.py
@@ -8,7 +8,6 @@ import sys
 import logging
 import subprocess
 import collections
-from typing import Dict, Tuple
 from argparse import ArgumentParser, ArgumentDefaultsHelpFormatter
 
 GIT_EXE = "git"
@@ -23,7 +22,7 @@ DEFAULT_PRIOR_TAG = "(prior_tag)"
 logger = logging.getLogger(__name__)
 
 
-def run_cmd(cmd: str) -> Tuple[str, str]:
+def run_cmd(cmd: str) -> tuple[str, str]:
     logger.debug("cmd: %s", cmd)
     p = subprocess.Popen(cmd.split(" "), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     out_, err_ = p.communicate()
@@ -34,7 +33,7 @@ def run_cmd(cmd: str) -> Tuple[str, str]:
     return out, err
 
 
-def get_diffs(cpath1: str, cpath2: str, percentage: str) -> Dict[str, list]:
+def get_diffs(cpath1: str, cpath2: str, percentage: str) -> dict[str, list]:
     cmd = f"{GIT_EXE} --no-pager diff --find-renames={percentage} --name-status {cpath1} {cpath2}"
     gdiff, err = run_cmd(cmd)
     # example output:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
 jobs:
 
   create_release:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -4,7 +4,7 @@ on:
     branches: [ master ]
 jobs:
   update_num_rules:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - name: Checkout capa-rules
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -23,7 +23,7 @@ jobs:
         color: blue
 
   sync_submodule_capa:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     needs: update_num_rules
     steps:
     # Do not checkout submodules as we don't need capa-testfiles and we need to
@@ -50,10 +50,10 @@ jobs:
     - name: Get modified files
       id: files
       uses: Ana06/get-changed-files@25f79e676e7ea1868813e21465014798211fad8c # v2.3.0
-    - name: Set up Python 3.9
+    - name: Set up Python 3.12
       uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0
       with:
-        python-version: 3.9
+        python-version: 3.12
     - name: Install Python dependencies
       run:
         pip install pyyaml

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ env:
 
 jobs:
   rule_linter:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       # expect this text in the PR body to trigger thorough lint of all rules
       LINT_THOROUGH: '[x] lint thorough all'
@@ -43,10 +43,10 @@ jobs:
         repository: mandiant/capa-testfiles
         path: tests/data
     # use latest available python for best performance
-    - name: Set up Python 3.11
+    - name: Set up Python 3.12
       uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0
       with:
-        python-version: 3.11
+        python-version: 3.12
     - name: Install capa
       run: pip install -e .
     # Regular lint is fast, so do this first
@@ -100,7 +100,7 @@ jobs:
   rules_latest_release:
     # e.g. v4
     if: startsWith(github.base_ref, 'v')
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Get latest release executable name and version
       run: |


### PR DESCRIPTION
ref: https://github.com/mandiant/capa/pull/2467