### PR TITLE
Add .NET AoT & TouchSocket linking detection 

### DIFF
--- a/linking/static/touchsocket/linked-against-touchsocket.yml
+++ b/linking/static/touchsocket/linked-against-touchsocket.yml
@@ -12,7 +12,7 @@ rule:
       - https://github.com/RRQM/TouchSocket/
       - https://www.trendmicro.com/en_us/research/24/i/earth-preta-new-malware-and-strategies.html
     examples:
-      - 3c45678eab01d28a971783263e8d1f73c0e6e989734121c1ae25f99ac6cb4e52
+      - 684cc28e6a7fbd12f23dbc563f06306555ebb870bd727ad60839d4ff26e7f3b2
   features:
     - and:
       - or:

--- a/linking/static/touchsocket/linked-against-touchsocket.yml
+++ b/linking/static/touchsocket/linked-against-touchsocket.yml
@@ -1,0 +1,27 @@
+rule:
+  meta:
+    name: linked against TouchSocket
+    namespace: linking/static/touchsocket
+    authors:
+      - still@teamt5.org
+    description: TouchSocket is a .NET networking library, supporting a wide variety of protocol types such as WebSocket, RPC, DMTP, Modbus, and more.
+    scopes:
+      static: file
+      dynamic: file
+    references:
+      - https://github.com/RRQM/TouchSocket/
+      - https://www.trendmicro.com/en_us/research/24/i/earth-preta-new-malware-and-strategies.html
+    examples:
+      - 3c45678eab01d28a971783263e8d1f73c0e6e989734121c1ae25f99ac6cb4e52
+  features:
+    - and:
+      - or:
+        - match: compiled to the .NET platform
+        - match: compiled with .NET AoT
+      - 3 or more:
+        - substring: "TouchSocket"
+        - substring: "TouchSocket.Core"
+        - substring: "TouchSocket.Dmtp"
+        - substring: "TouchSocket.Modbus"
+        - substring: "BinarySerialize"
+        - substring: "BinaryDeserialize"

--- a/runtime/dotnet/compiled-with-dotnet-aot.yml
+++ b/runtime/dotnet/compiled-with-dotnet-aot.yml
@@ -1,0 +1,23 @@
+rule:
+  meta:
+    name: compiled with .NET AoT
+    namespace: runtime/dotnet
+    authors:
+      - still@teamt5.org
+    description: compiled using .NET Ahead-of-Time (AoT) compilation
+    scopes:
+      static: file
+      dynamic: file
+    references:
+      - https://learn.microsoft.com/en-us/dotnet/core/deploying/native-aot/
+    examples:
+      - 3c45678eab01d28a971783263e8d1f73c0e6e989734121c1ae25f99ac6cb4e52
+  features:
+    - and:
+      - substring: ".NETCoreApp,Version="
+      - 2 or more:
+        - substring: "AotAnalysis4IL"
+        - substring: "https://aka.ms/nativeaot-compatibilit"
+        - substring: "removed by the AOT compiler"
+        - substring: "\\native\\"
+          description: During compilation, the output by default contains the path "native," which is then in turn included in the PDB path.

--- a/runtime/dotnet/compiled-with-dotnet-aot.yml
+++ b/runtime/dotnet/compiled-with-dotnet-aot.yml
@@ -11,7 +11,7 @@ rule:
     references:
       - https://learn.microsoft.com/en-us/dotnet/core/deploying/native-aot/
     examples:
-      - 3c45678eab01d28a971783263e8d1f73c0e6e989734121c1ae25f99ac6cb4e52
+      - 684cc28e6a7fbd12f23dbc563f06306555ebb870bd727ad60839d4ff26e7f3b2
   features:
     - and:
       - substring: ".NETCoreApp,Version="


### PR DESCRIPTION
<!--
Thank you for contributing to capa! <3

Please ensure that:
1. each rule passes thorough linting (in rules directory: `python ../scripts/lint.py --thorough -t "<your rule name>" -v .`)
2. you've uploaded each referenced example binary (optional, but greatly appreciated) to https://github.com/mandiant/capa-testfiles

Please mention the issue your PR addresses (if any):
closes #issue_number
-->

## Summary

This PR adds a new rule for detecting .NET binaries that are compiled Ahead-of-Time (AoT), as well as another rule for detecting strings related to the TouchSocket library, a Chinese-developed networking library that has been adopted by at least one Chinese APT group. 

## Related Sample

Additional discussion is required surrounding the example linked in the rule, as both of the rules feature a sample that is a known malicious sample that exceeds 15MB in size and can cause a significant amount of time to process, and may cause timeout for the CI pipeline. I can replace this with a self-written sample Hello World that would meet the requirements for both of these rules and be significantly smaller (~1.6MB) and faster, if other maintainers believe this would be a better approach.