### PR TITLE
Change dynamic scope to call for atomic operations

### DIFF
--- a/host-interaction/file-system/copy/copy-file.yml
+++ b/host-interaction/file-system/copy/copy-file.yml
@@ -7,7 +7,7 @@ rule:
       - michael.hunhoff@mandiant.com
     scopes:
       static: function
-      dynamic: thread
+      dynamic: call
     mbc:
       - File System::Copy File [C0045]
     examples:

--- a/host-interaction/file-system/move/move-file.yml
+++ b/host-interaction/file-system/move/move-file.yml
@@ -7,7 +7,7 @@ rule:
       - michael.hunhoff@mandiant.com
     scopes:
       static: function
-      dynamic: thread
+      dynamic: call
     mbc:
       - File System::Move File [C0063]
     examples:

--- a/host-interaction/file-system/write/write-file-on-windows.yml
+++ b/host-interaction/file-system/write/write-file-on-windows.yml
@@ -7,7 +7,7 @@ rule:
       - anushka.virgaonkar@mandiant.com
     scopes:
       static: function
-      dynamic: thread
+      dynamic: call
     mbc:
       - File System::Writes File [C0052]
     examples:

--- a/host-interaction/registry/create/set-registry-value.yml
+++ b/host-interaction/registry/create/set-registry-value.yml
@@ -7,7 +7,7 @@ rule:
       - michael.hunhoff@mandiant.com
     scopes:
       static: function
-      dynamic: thread
+      dynamic: call
     mbc:
       - Operating System::Registry::Set Registry Key [C0036.001]
     examples:


### PR DESCRIPTION
To reduce false positives, we change the dynamic scope of a couple of operations to `call`.
E.g., writing to the registry is always done in one Windows API call, so we change the scope from `thread` to `call`.

Original discussion: https://github.com/mandiant/capa-rules/discussions/951