### PR TITLE
Add rules for various stealer techniques

### DIFF
--- a/collection/browser/get-chrome-cookiemonster.yml
+++ b/collection/browser/get-chrome-cookiemonster.yml
@@ -1,0 +1,25 @@
+rule:
+  meta:
+    name: get Chrome CookieMonster
+    namespace: collection/browser
+    authors:
+      - still@teamt5.org
+    description: finds sections related to Chrome's CookieMonster component, typically used in conjunction with code that dumps cookies from Chromium-based browsers
+    scopes:
+      static: file
+      dynamic: process
+    att&ck:
+      - Credential Access::Credentials from Password Stores::Credentials from Web Browsers [T1555.003]
+    references:
+      - https://github.com/Meckazin/ChromeKatz/blob/main/CookieKatz-BOF/CookieKatzBOF.cpp
+    examples:
+      - 79f5cabff898d60cd614e7254d409d9c2e05184416e5c54201e2dc216998d28b:0x117D
+  features:
+    - and:
+      - substring: "network.mojom.NetworkService" # process with CookieMonster
+      - or:
+        - substring: "chrome.dll"
+        - substring: "chrome.exe"
+        - substring: "msedge.exe"
+        - substring: "msedgewebview2.exe"
+        - substring: "msedge.dll"

--- a/collection/browser/get-chrome-elevation-service.yml
+++ b/collection/browser/get-chrome-elevation-service.yml
@@ -1,0 +1,44 @@
+rule:
+  meta:
+    name: get Chrome elevation service
+    namespace: collection/browser
+    authors:
+      - still@teamt5.org
+    description: finds strings/identifiers related to Chrome Elevation Service, typically used in conjunction with retrieving App-bound Encryption related key
+    scopes:
+      static: function
+      dynamic: unsupported  # requires bytes features
+    att&ck:
+      - Credential Access::Exploitation for Credential Access [T1212]
+      - Credential Access::Credentials from Password Stores::Credentials from Web Browsers [T1555.003]
+    references:
+      - https://gist.github.com/snovvcrash/caded55a318bbefcb6cc9ee30e82f824
+      - https://chromium.googlesource.com/chromium/src/+/HEAD/chrome/install_static/install_util_unittest.cc
+    examples:
+      - fb690a23b66d4f90dac83f1b4d6dec0074aff68d6ef62c2613120bd4d17cfbdd:0x14006E8C0
+  features:
+    - and:
+      - optional:
+        - string: "APPB"
+          description: prefix for App-bound Encryption encrypted credentials
+      - or:
+        - 2 or more:
+          - bytes: CF BE 3A 46 0D 41 7F 40 8A F5 0D F3 5A 00 5C C8 = IID for Google Chrome
+          - bytes: E0 60 88 70 41 F6 11 46 88 95 7D 86 7D D3 67 5B = CLSID for Google Chrome
+          - substring: "{708860E0-F641-4611-8895-7D867DD3675B}"
+            description: CLSID for Google Chrome
+        - 2 or more:
+          - bytes: 66 1D 72 A2 6E 37 2F 4D 9F 0F 90 70 E9 A4 2B 5F = IID for Google Chrome Beta
+          - bytes: BA 46 26 DD 07 37 F8 4B B9 A7 03 86 91 A6 8F C2 = CLSID for Google Chrome Beta
+          - substring: "{DD2646BA-3707-4BF8-B9A7-038691A68FC2}"
+            description: CLSID for Google Chrome Beta
+        - 2 or more:
+          - bytes: 6B A2 2A BB 3A 34 72 40 8B 6F 80 55 7B 8C E5 71 = IID for Google Chrome Dev
+          - bytes: A5 DC 7F DA AA 2C 37 46 AA 17 07 40 58 4D E7 DA = CLSID for Google Chrome Dev
+          - substring: "{DA7FDCA5-2CAA-4637-AA17-0740584DE7DA}"
+            description: CLSID for Google Chrome Dev
+        - 2 or more:
+          - bytes: 41 E0 7C 4F E9 28 4F 48 9D D0 61 A8 CA CE FE E4 = IID for Google Chrome Canary
+          - bytes: 72 28 4C 70 49 20 5E 43 A4 69 0A 53 43 13 C4 2B = CLSID for Google Chrome Canary
+          - substring: "{704C2872-2049-435E-A469-0A534313C42B}"
+            description: CLSID for Google Chrome Canary

--- a/collection/browser/get-elevation-service-for-chromium-based-browsers.yml
+++ b/collection/browser/get-elevation-service-for-chromium-based-browsers.yml
@@ -1,6 +1,6 @@
 rule:
   meta:
-    name: get Chrome elevation service
+    name: get elevation service for Chromium-based browsers
     namespace: collection/browser
     authors:
       - still@teamt5.org
@@ -42,3 +42,9 @@ rule:
           - bytes: 72 28 4C 70 49 20 5E 43 A4 69 0A 53 43 13 C4 2B = CLSID for Google Chrome Canary
           - substring: "{704C2872-2049-435E-A469-0A534313C42B}"
             description: CLSID for Google Chrome Canary
+        - 2 or more:
+          # untested
+          - bytes: 07 B8 C2 C9 31 77 34 4F 81 B7 44 FF 77 79 52 2B = IID for Microsoft Edge
+          - bytes: 6C E9 CB 1F 97 16 AF 43 91 40 28 97 C7 C6 97 67 = CLSID for Microsoft Edge
+          - substring: "{1FCBE96C-1697-43AF-9140-2897C7C69767}"
+            description: CLSID for Microsoft Edge

--- a/collection/get-steam-token.yml
+++ b/collection/get-steam-token.yml
@@ -6,7 +6,7 @@ rule:
       - still@teamt5.org
     description: locates references to Steam authentication token via the beginning of a Steam bearer token
     scopes:
-      static: file
+      static: function
       dynamic: unsupported # requires bytes feature
     examples:
       - 2c83f152e09d0abaa3a3784669e75276784e50e1e202d16ab27e5741eef9ab4f:0x0041718C

--- a/collection/get-steam-token.yml
+++ b/collection/get-steam-token.yml
@@ -12,6 +12,5 @@ rule:
       - 2c83f152e09d0abaa3a3784669e75276784e50e1e202d16ab27e5741eef9ab4f:0x0041718C
   features:
     - or:
-      - bytes: 65 79 41 69 64 48 6C 77 49 6A 6F 67 49 6B 70 58 56 43 49 73 49 43 4A
       - string: "65 79 41 69 64 48 6C 77 49 6A 6F 67 49 6B 70 58 56 43 49 73 49 43 4A"
       - substring: "eyAidHlwIjogIkpXVCIsICJ"

--- a/collection/get-steam-token.yml
+++ b/collection/get-steam-token.yml
@@ -7,10 +7,11 @@ rule:
     description: locates references to Steam authentication token via the beginning of a Steam bearer token
     scopes:
       static: file
-      dynamic: process
+      dynamic: unsupported # requires bytes feature
     examples:
       - 2c83f152e09d0abaa3a3784669e75276784e50e1e202d16ab27e5741eef9ab4f:0x0041718C
   features:
     - or:
+      - bytes: 65 79 41 69 64 48 6C 77 49 6A 6F 67 49 6B 70 58 56 43 49 73 49 43 4A
       - string: "65 79 41 69 64 48 6C 77 49 6A 6F 67 49 6B 70 58 56 43 49 73 49 43 4A"
-      - string: "eyAidHlwIjogIkpXVCIsICJ"
+      - substring: "eyAidHlwIjogIkpXVCIsICJ"

--- a/collection/get-steam-token.yml
+++ b/collection/get-steam-token.yml
@@ -12,5 +12,5 @@ rule:
       - 2c83f152e09d0abaa3a3784669e75276784e50e1e202d16ab27e5741eef9ab4f:0x0041718C
   features:
     - or:
-      - string: "65 79 41 69 64 48 6C 77 49 6A 6F 67 49 6B 70 58 56 43 49 73 49 43 4A"
+      - substring: "65 79 41 69 64 48 6C 77 49 6A 6F 67 49 6B 70 58 56 43 49 73 49 43 4A"
       - substring: "eyAidHlwIjogIkpXVCIsICJ"

--- a/collection/get-steam-token.yml
+++ b/collection/get-steam-token.yml
@@ -1,0 +1,16 @@
+rule:
+  meta:
+    name: get Steam token
+    namespace: collection
+    authors:
+      - still@teamt5.org
+    description: locates references to Steam authentication token via the beginning of a Steam bearer token
+    scopes:
+      static: file
+      dynamic: process
+    examples:
+      - 2c83f152e09d0abaa3a3784669e75276784e50e1e202d16ab27e5741eef9ab4f:0x0041718C
+  features:
+    - or:
+      - string: "65 79 41 69 64 48 6C 77 49 6A 6F 67 49 6B 70 58 56 43 49 73 49 43 4A"
+      - string: "eyAidHlwIjogIkpXVCIsICJ"


### PR DESCRIPTION
<!--
Thank you for contributing to capa! <3

Please ensure that:
1. each rule passes thorough linting (in rules directory: `python ../scripts/lint.py --thorough -t "<your rule name>" -v .`)
2. you've uploaded each referenced example binary (optional, but greatly appreciated) to https://github.com/mandiant/capa-testfiles

Please mention the issue your PR addresses (if any):
closes #issue_number
-->

## Summary

This PR adds three new rules spotted amongst various types of infostealers/dumping tools (Stealc, Vidar, ChromeKatz),
1. `collection/browser/get-chrome-cookiemonster.yml`
    - Detects strings related to locating processes related to Chromium's [CookieMonster class](https://www.chromium.org/developers/design-documents/network-stack/cookiemonster/)
    - Typically used by infostealers or memory dumpers to extract Cookies directly from Chromium-based browsers
2. `collection/browser/get-chrome-elevation-service.yml`
   - Detects IID and CLSIDs for Chrome ElevationService of various editions
   - Typically used by infostealers via RPC to decrypt App-bound Encryption-related data
3. `collection/get-steam-token.yml`
   - Detects references to known Steam tokens
   - Typically used by Vidar and its relevant families of infostealer by scanning Steam process to retrieve the user login token.