### PR TITLE
tmp: update to newscope (placeholder)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ rule:
       - moritz.raabe@mandiant.com
     scopes:
       static: function
-      dynamic: thread
+      dynamic: newscope
     att&ck:
       - Execution::Command and Scripting Interpreter::Windows Command Shell [T1059.003]
     mbc:

--- a/anti-analysis/anti-av/check-for-sandbox-and-av-modules.yml
+++ b/anti-analysis/anti-av/check-for-sandbox-and-av-modules.yml
@@ -6,7 +6,7 @@ rule:
       - "@_re_fox"
     scopes:
       static: basic block
-      dynamic: thread
+      dynamic: newscope
     mbc:
       - Anti-Behavioral Analysis::Virtual Machine Detection [B0009]
       - Anti-Behavioral Analysis::Sandbox Detection [B0007]

--- a/anti-analysis/anti-av/overwrite-dll-text-section-to-remove-hooks.yml
+++ b/anti-analysis/anti-av/overwrite-dll-text-section-to-remove-hooks.yml
@@ -6,7 +6,7 @@ rule:
       - jakub.jozwiak@mandiant.com
     scopes:
       static: function
-      dynamic: thread
+      dynamic: newscope
     att&ck:
       - Defense Evasion::Impair Defenses::Disable or Modify Tools [T1562.001]
     mbc:

--- a/anti-analysis/anti-av/patch-antimalware-scan-interface-function.yml
+++ b/anti-analysis/anti-av/patch-antimalware-scan-interface-function.yml
@@ -6,7 +6,7 @@ rule:
       - jakub.jozwiak@mandiant.com
     scopes:
       static: function
-      dynamic: thread
+      dynamic: newscope
     att&ck:
       - Defense Evasion::Impair Defenses::Disable or Modify Tools [T1562.001]
     mbc:

--- a/anti-analysis/anti-av/patch-event-tracing-for-windows-function.yml
+++ b/anti-analysis/anti-av/patch-event-tracing-for-windows-function.yml
@@ -6,7 +6,7 @@ rule:
       - jakub.jozwiak@mandiant.com
     scopes:
       static: function
-      dynamic: thread
+      dynamic: newscope
     att&ck:
       - Defense Evasion::Impair Defenses::Disable or Modify Tools [T1562.001]
     mbc:

--- a/anti-analysis/anti-debugging/debugger-detection/check-for-outputdebugstring-error.yml
+++ b/anti-analysis/anti-debugging/debugger-detection/check-for-outputdebugstring-error.yml
@@ -6,7 +6,7 @@ rule:
       - michael.hunhoff@mandiant.com
     scopes:
       static: basic block
-      dynamic: thread
+      dynamic: newscope
     mbc:
       - Anti-Behavioral Analysis::Debugger Detection::OutputDebugString [B0001.016]
     examples:

--- a/anti-analysis/anti-debugging/debugger-detection/check-for-protected-handle-exception.yml
+++ b/anti-analysis/anti-debugging/debugger-detection/check-for-protected-handle-exception.yml
@@ -6,7 +6,7 @@ rule:
       - michael.hunhoff@mandiant.com
     scopes:
       static: function
-      dynamic: thread
+      dynamic: newscope
     mbc:
       - Anti-Behavioral Analysis::Debugger Detection::SetHandleInformation [B0001.024]
     references:

--- a/anti-analysis/anti-debugging/debugger-detection/check-for-time-delay-via-queryperformancecounter.yml
+++ b/anti-analysis/anti-debugging/debugger-detection/check-for-time-delay-via-queryperformancecounter.yml
@@ -6,7 +6,7 @@ rule:
       - michael.hunhoff@mandiant.com
     scopes:
       static: function
-      dynamic: thread
+      dynamic: newscope
     mbc:
       - Anti-Behavioral Analysis::Debugger Detection::Timing/Delay Check QueryPerformanceCounter [B0001.033]
     examples:

--- a/anti-analysis/anti-debugging/debugger-detection/check-process-job-object.yml
+++ b/anti-analysis/anti-debugging/debugger-detection/check-process-job-object.yml
@@ -6,7 +6,7 @@ rule:
       - michael.hunhoff@mandiant.com
     scopes:
       static: function
-      dynamic: thread
+      dynamic: newscope
     mbc:
       - Anti-Behavioral Analysis::Debugger Detection [B0001]
     references:

--- a/anti-analysis/anti-debugging/debugger-evasion/hide-thread-from-debugger.yml
+++ b/anti-analysis/anti-debugging/debugger-evasion/hide-thread-from-debugger.yml
@@ -7,7 +7,7 @@ rule:
       - jakub.jozwiak@mandiant.com
     scopes:
       static: function
-      dynamic: thread
+      dynamic: newscope
     att&ck:
       - Defense Evasion::Debugger Evasion [T1622]
     mbc:

--- a/anti-analysis/anti-emulation/wine/check-if-process-is-running-under-wine.yml
+++ b/anti-analysis/anti-emulation/wine/check-if-process-is-running-under-wine.yml
@@ -6,7 +6,7 @@ rule:
       - "@_re_fox"
     scopes:
       static: function
-      dynamic: thread
+      dynamic: newscope
     att&ck:
       - Defense Evasion::Virtualization/Sandbox Evasion::System Checks [T1497.001]
     mbc:

--- a/anti-analysis/anti-forensic/clear-logs/clear-windows-event-logs.yml
+++ b/anti-analysis/anti-forensic/clear-logs/clear-windows-event-logs.yml
@@ -6,7 +6,7 @@ rule:
       - michael.hunhoff@mandiant.com
     scopes:
       static: function
-      dynamic: thread
+      dynamic: newscope
     att&ck:
       - Defense Evasion::Indicator Removal::Clear Windows Event Logs [T1070.001]
     examples:

--- a/anti-analysis/anti-forensic/crash-the-windows-event-logging-service.yml
+++ b/anti-analysis/anti-forensic/crash-the-windows-event-logging-service.yml
@@ -6,7 +6,7 @@ rule:
       - michael.hunhoff@mandiant.com
     scopes:
       static: basic block
-      dynamic: thread
+      dynamic: newscope
     att&ck:
       - Defense Evasion::Impair Defenses::Disable Windows Event Logging [T1562.002]
     references:

--- a/anti-analysis/anti-forensic/impersonate-file-version-information.yml
+++ b/anti-analysis/anti-forensic/impersonate-file-version-information.yml
@@ -7,7 +7,7 @@ rule:
     description: Looks for Windows API calls associated with reading and then writing file version information of executables on disk. Malware can use these calls to overwrite its own version information with that of a legitimate executable on the system (for instance, explorer.exe) to make it appear to be a legitimate application.
     scopes:
       static: function
-      dynamic: thread
+      dynamic: newscope
     att&ck:
       - Defense Evasion::Indicator Removal [T1070]
     references:

--- a/anti-analysis/anti-forensic/self-deletion/self-delete-using-alternate-data-streams.yml
+++ b/anti-analysis/anti-forensic/self-deletion/self-delete-using-alternate-data-streams.yml
@@ -6,7 +6,7 @@ rule:
       - daniel.stepanic@elastic.co
     scopes:
       static: function
-      dynamic: thread
+      dynamic: newscope
     att&ck:
       - Defense Evasion::Indicator Removal::File Deletion [T1070.004]
     mbc:

--- a/anti-analysis/anti-forensic/self-deletion/self-delete.yml
+++ b/anti-analysis/anti-forensic/self-deletion/self-delete.yml
@@ -7,7 +7,7 @@ rule:
       - "@mr-tz"
     scopes:
       static: function
-      dynamic: thread
+      dynamic: newscope
     att&ck:
       - Defense Evasion::Indicator Removal::File Deletion [T1070.004]
     mbc:

--- a/anti-analysis/anti-forensic/timestomp/timestomp-file.yml
+++ b/anti-analysis/anti-forensic/timestomp/timestomp-file.yml
@@ -6,7 +6,7 @@ rule:
       - moritz.raabe@mandiant.com
     scopes:
       static: function
-      dynamic: thread
+      dynamic: newscope
     att&ck:
       - Defense Evasion::Indicator Removal::Timestomp [T1070.006]
     examples:

--- a/anti-analysis/anti-vm/vm-detection/check-for-microsoft-office-emulation.yml
+++ b/anti-analysis/anti-vm/vm-detection/check-for-microsoft-office-emulation.yml
@@ -6,7 +6,7 @@ rule:
       - "@_re_fox"
     scopes:
       static: function
-      dynamic: thread
+      dynamic: newscope
     att&ck:
       - Defense Evasion::Virtualization/Sandbox Evasion::System Checks [T1497.001]
     mbc:

--- a/anti-analysis/anti-vm/vm-detection/check-for-sandbox-username-or-hostname.yml
+++ b/anti-analysis/anti-vm/vm-detection/check-for-sandbox-username-or-hostname.yml
@@ -7,7 +7,7 @@ rule:
       - "echernofsky@google.com"
     scopes:
       static: function
-      dynamic: thread
+      dynamic: newscope
     att&ck:
       - Defense Evasion::Virtualization/Sandbox Evasion [T1497]
     mbc:


### PR DESCRIPTION
In support of https://github.com/mandiant/capa/pull/2532

Per these manual test updates it's pretty clear, that we can update all rules with scope `dynamic: thread` to `dynamic: <newscope>`.

By definition of the associated static scopes (`basic block` and `function`) we expect all rules to match in close proximity.

Issues arise potentially for loops or API hammering (or just other interspersed API calls).