### PR TITLE
update create-process-suspended to include DEBUG_ONLY_THIS_PROCESS

### DIFF
--- a/host-interaction/process/create/create-process-suspended.yml
+++ b/host-interaction/process/create/create-process-suspended.yml
@@ -4,6 +4,7 @@ rule:
     namespace: host-interaction/process/create
     authors:
       - william.ballenthin@mandiant.com
+      - mehunhoff@google.com
     scopes:
       static: basic block
       dynamic: call
@@ -16,6 +17,7 @@ rule:
       - or:
         - number: 0x08000004 = CREATE_NO_WINDOW | CREATE_SUSPENDED
         - number: 4 = CREATE_SUSPENDED
+        - number: 2 = DEBUG_ONLY_THIS_PROCESS
       - or:
         - api: kernel32.CreateProcess
         - api: advapi32.CreateProcessAsUser

--- a/host-interaction/process/create/create-process-suspended.yml
+++ b/host-interaction/process/create/create-process-suspended.yml
@@ -10,6 +10,9 @@ rule:
       dynamic: call
     mbc:
       - Process::Create Process::Create Suspended Process [C0017.003]
+    references:
+      - https://www.trustwave.com/en-us/resources/blogs/spiderlabs-blog/an-in-depth-look-at-mailto-ransomware-part-two-of-three/
+      - https://learn.microsoft.com/en-us/windows/win32/procthread/process-creation-flags#flags
     examples:
       - Practical Malware Analysis Lab 03-03.exe_:0x4010EA
   features:


### PR DESCRIPTION
> With the Debug Injection method, the ransomware first uses the function “CreateProcessW” with the “DEBUG_ONLY_THIS_PROCESS” creation flag. Creating the “Explorer.exe” process in this state allows the ransomware to suspend the process and modify its memory. This is when then ransomware calls “NtMapViewOfSection” to copy itself to the process and fix its relocations. Afterward, it calls “NtGetContextThread” to receive the thread context of the main thread for “Explorer.exe”. It then sets the instruction pointer (EIP) to the mapped ransomware’s selected entry point. “ContinueDebugEvent” is then called to continue the execution of “Explorer.exe” and the following call is to “DebugActiveProcessStop” which finally detaches the ransomware’s debugger from the process.

_source: https://www.trustwave.com/en-us/resources/blogs/spiderlabs-blog/an-in-depth-look-at-mailto-ransomware-part-two-of-three/_

```
DEBUG_ONLY_THIS_PROCESS (0x00000002)
The calling thread starts and debugs the new process. It can receive all related debug events using the WaitForDebugEvent function.
```
