### PR TITLE
Add CONTRIBUTING file & update ISSUE TEMPLATES

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,51 @@
+# Contributing capa rules
+
+First off, thanks for taking the time to contribute! :sparkling_heart:
+
+## What should I know before I get started?
+
+### Code of Conduct
+
+This project follows [Google's Open Source Community Guidelines](https://opensource.google/conduct).
+
+### capa and its repositories
+
+We host the capa project as three GitHub repositories:
+  - **[capa-rules](https://github.com/mandiant/capa-rules) (this repository)**: The standard rules contributed by the community.
+  - **[capa](https://github.com/mandiant/capa)**: The command line tools, logic engine, and other Python source code.
+  - **[capa-testfiles](https://github.com/mandiant/capa-testfiles)**: Test fixtures, such as malware samples.
+
+### Documentation
+
+- [README](README.md)
+- [rule format page](doc/format.md)
+
+## How Can I Contribute?
+
+### Issues
+
+Open an [issue](https://github.com/mandiant/capa-rules/issues) to share a rules idea and report false positives/negatives. Check the open issues and ensure there is not already a similar issue.
+
+### Code (rule contributions)
+
+Extend and enhance our rule set with a rule contributions based on your own ideas or the [rule-idea](https://github.com/mandiant/capa-rules/issues?q=is%3Aissue+is%3Aopen+label%3A%22rule+idea%22) issues.
+
+#### Before contributing code
+Before sending a pull request (PR):
+
+1. Sign the [Contributor License Agreement](#contributor-license-agreement)
+2. Ensure each rule passes thorough linting (in rules directory: `python ../scripts/lint.py --thorough -t "<your rule name>" -v .`)
+3. [OPTIONAL, but greatly appreciated] Upload each referenced example binary to https://github.com/mandiant/capa-testfiles
+4. Please mention the issue your PR addresses (if any) in the PR description:
+   ```
+   closes https://github.com/mandiant/capa-rules/issues/<issue_number>
+   ```
+
+##### Contributor License Agreement
+
+Contributions to this project must be accompanied by a [Contributor License Agreement](https://cla.developers.google.com/about) (CLA).
+You (or your employer) retain the copyright to your contribution; this simply gives us permission to use and redistribute your contributions as part of the project.
+
+If you or your current employer have already signed the Google CLA (even if it was for a different project), you probably don't need to do it again.
+
+Visit <https://cla.developers.google.com/> to see your current agreements or to sign a new one.

--- a/.github/ISSUE_TEMPLATE/false_negative.md
+++ b/.github/ISSUE_TEMPLATE/false_negative.md
@@ -7,8 +7,7 @@ labels: false negative
 ---
 
 <!--
-
-Have you read capa's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/mandiant/capa/blob/master/CODE_OF_CONDUCT.md
+Have you read Google's Code of Conduct? By filing an issue, you are expected to comply with it, including treating everyone with respect: https://opensource.google/conduct
 -->
 
 ## Summary

--- a/.github/ISSUE_TEMPLATE/false_positive.md
+++ b/.github/ISSUE_TEMPLATE/false_positive.md
@@ -7,8 +7,7 @@ labels: false positive
 ---
 
 <!--
-
-Have you read capa's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/mandiant/capa/blob/master/CODE_OF_CONDUCT.md
+Have you read Google's Code of Conduct? By filing an issue, you are expected to comply with it, including treating everyone with respect: https://opensource.google/conduct
 -->
 
 ## Summary

--- a/.github/ISSUE_TEMPLATE/rule_idea.md
+++ b/.github/ISSUE_TEMPLATE/rule_idea.md
@@ -11,7 +11,7 @@ Please use your proposed rule name as issue title. See convention at https://git
 
 The more information you can provide the better. However, we would rather collect more ideas than miss an interesting rule because of the amount of required data. So in that case you submit whatever you can.    
 
-Have you read capa's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/mandiant/capa/blob/master/CODE_OF_CONDUCT.md
+Have you read Google's Code of Conduct? By filing an issue, you are expected to comply with it, including treating everyone with respect: https://opensource.google/conduct
 -->
 
 ## Prerequisites


### PR DESCRIPTION
- Change the Code of Conduct by Google's default Code of Conduct in the ISSUE TEMPLATES, as the used linked has been removed from capa in https://github.com/mandiant/capa/pull/2556 for consistency with other Google projects.
- Add CONTRIBUTING file with information about CLA and Google's code of conduct to follow Google conventions/policies. Include also other details to make contributing easier. We can add more details in the future to this file too.