### PR TITLE
remove duplicate features from some rules

### DIFF
--- a/anti-analysis/anti-vm/vm-detection/reference-anti-vm-strings-targeting-virtualbox.yml
+++ b/anti-analysis/anti-vm/vm-detection/reference-anti-vm-strings-targeting-virtualbox.yml
@@ -55,7 +55,6 @@ rule:
       - string: /\\\\.\\pipe\\VBoxTrayIPC/i
       - string: /VBoxTrayToolWndClass/i
       - string: /VBoxTrayToolWnd/i
-      - string: /vboxservice\.exe/i
       - string: /vboxtray.exe/i
       - string: /vboxvideo/i
       - string: /VBoxVideoW8/i

--- a/anti-analysis/anti-vm/vm-detection/reference-anti-vm-strings-targeting-vmware.yml
+++ b/anti-analysis/anti-vm/vm-detection/reference-anti-vm-strings-targeting-vmware.yml
@@ -56,7 +56,6 @@ rule:
       - string: /vmx86/i
       - string: /VMwareVMware/i
       - string: /vmGuestLib\.dll/i
-      - string: /vmGuestLib\.dll/i
       - string: /Applications\\VMwareHostOpen\.exe/i
       - string: /vm3dgl\.dll/i
       - string: /vmdum\.dll/i

--- a/anti-analysis/anti-vm/vm-detection/reference-anti-vm-strings-targeting-xen.yml
+++ b/anti-analysis/anti-vm/vm-detection/reference-anti-vm-strings-targeting-xen.yml
@@ -20,5 +20,4 @@ rule:
       - string: /^Xen/i
       - string: /XenVMMXenVMM/i
       - string: /xenservice.exe/i
-      - string: /XenVMMXenVMM/i
       - string: /HVM domU/i

--- a/communication/socket/tcp/create-tcp-socket-via-raw-afd-driver.yml
+++ b/communication/socket/tcp/create-tcp-socket-via-raw-afd-driver.yml
@@ -41,6 +41,7 @@ rule:
             - number: 0x64 = d
             - number: 0x4F = O
             - number: 0x70 = p
+            # - number: 0x65 = e
             - number: 0x6E = n
             - number: 0x50 = P
             - number: 0x61 = a
@@ -52,6 +53,7 @@ rule:
             - number: 0x02
             - number: 0x01
             - number: 0x06
+            # - number: 0x00
             - number: 0x60
             - number: 0xEF
             - number: 0x3D

--- a/communication/socket/tcp/create-tcp-socket-via-raw-afd-driver.yml
+++ b/communication/socket/tcp/create-tcp-socket-via-raw-afd-driver.yml
@@ -41,7 +41,6 @@ rule:
             - number: 0x64 = d
             - number: 0x4F = O
             - number: 0x70 = p
-            - number: 0x65 = e
             - number: 0x6E = n
             - number: 0x50 = P
             - number: 0x61 = a
@@ -53,7 +52,6 @@ rule:
             - number: 0x02
             - number: 0x01
             - number: 0x06
-            - number: 0x00
             - number: 0x60
             - number: 0xEF
             - number: 0x3D

--- a/nursery/send-data-to-internet.yml
+++ b/nursery/send-data-to-internet.yml
@@ -24,6 +24,5 @@ rule:
         - api: System.Net.WebClient::UploadString
         - api: System.Net.WebClient::UploadStringAsync
         - api: System.Net.WebClient::UploadStringTaskAsync
-        - api: System.Net.WebClient::UploadValues
         - api: System.Net.WebClient::UploadValuesAsync
         - api: System.Net.WebClient::UploadValuesTaskAsync

--- a/persistence/office/act-as-office-com-add-in.yml
+++ b/persistence/office/act-as-office-com-add-in.yml
@@ -20,7 +20,6 @@ rule:
       - class: Extensibility.IDTExtensibility2
       - or:
         - string: "OnAddInsUpdate"
-        - string: "OnAddInsUpdate"
         - string: "OnBeginShutdown"
         - string: "OnConnection"
         - string: "OnDisconnection"


### PR DESCRIPTION
<!--
Thank you for contributing to capa! <3

Please ensure that:
1. each rule passes thorough linting (in rules directory: `python ../scripts/lint.py --thorough -t "<your rule name>" -v .`)
2. you've uploaded each referenced example binary (optional, but greatly appreciated) to https://github.com/mandiant/capa-testfiles

Please mention the issue your PR addresses (if any):
closes #issue_number
-->
removing duplicate features found in following rules using new lint (https://github.com/mandiant/capa/pull/257):
  - act as Office COM add-in
  - create TCP socket via raw AFD driver
  - reference anti-VM strings targeting VMWare
  - reference anti-VM strings targeting VirtualBox
  - reference anti-VM strings targeting Xen
  - send data to Internet