### PR TITLE
reduce fps for self-delete.yml

### DIFF
--- a/anti-analysis/anti-forensic/self-deletion/self-delete.yml
+++ b/anti-analysis/anti-forensic/self-deletion/self-delete.yml
@@ -23,8 +23,8 @@ rule:
       - or:
         - string: /\/c\s*del\s*/
           description: "/c del"
-        - string: /del\s*\S/
-          description: "del \"%s\""
+        - string: /(^|[\&;\|]\s*)del(\s.*)?/i
+          description: "echo 1&&del /path/to/file"
       - optional:
         - string: /\s*>\s*nul\s*/i
           description: "> nul"


### PR DESCRIPTION
Removes FP regex match `/del\s*\S/` for `api-ms-win-appmodel-runtime-l1-1-2` discovered during testing.

Input:
```
del /path/to/file
del "/path/to/file"
api-ms-win-appmodel-runtime-l1-1-2
cmd.exe /c "ping 127.0.0.1 & del \"/path/to/file\""
cmd.exe /c "ping 127.0.0.1&del \"/path/to/file\""
```
Matches:
```
del /path/to/file
del "/path/to/file"
& del \"/path/to/file\""
&del \"/path/to/file\""
```