### PR TITLE
CI rule linter error:scope interchanged

### DIFF
--- a/host-interaction/file-system/windows-file-protection/bypass-windows-file-protection.yml
+++ b/host-interaction/file-system/windows-file-protection/bypass-windows-file-protection.yml
@@ -6,7 +6,7 @@ rule:
       - michael.hunhoff@mandiant.com
     scopes:
       static: function
-      dynamic: span of calls
+      dynamic: thread
     mbc:
       - Defense Evasion::Disable or Evade Security Tools::Bypass Windows File Protection [F0004.007]
     examples:

--- a/linking/runtime-linking/link-many-functions-at-runtime.yml
+++ b/linking/runtime-linking/link-many-functions-at-runtime.yml
@@ -7,7 +7,7 @@ rule:
       - joakim@intezer.com
     scopes:
       static: function
-      dynamic: thread
+      dynamic: span of calls
     att&ck:
       - Execution::Shared Modules [T1129]
     examples:


### PR DESCRIPTION
The PR https://github.com/mandiant/capa/pull/2581 for issue#2572 gives a rule linter error. As the files are in submodule rules this also needed a update to pass CI error their.

@williballenthin 

[x] No CHANGELOG update needed
[x] No new tests needed
[x] No documentation update needed