### PR TITLE
internal-dotnet-file-limitation.yml: make it valid for static scope too

### DIFF
--- a/internal/limitation/dynamic/internal-dotnet-file-limitation.yml
+++ b/internal/limitation/dynamic/internal-dotnet-file-limitation.yml
@@ -10,7 +10,7 @@ rule:
       capa rules are not yet tuned for the .NET runtime, 
       so its analysis may be incomplete or misleading.
     scopes:
-      static: unsupported
+      static: file
       dynamic: file
     examples:
       - 2f8a79b12a7a989ac7e5f6ec65050036588a92e65aeb6841e08dc228ff0e21b4_min_archive.zip


### PR DESCRIPTION
ref https://github.com/mandiant/capa/issues/2591


<!--
Thank you for contributing to capa! <3

Please ensure that:
1. each rule passes thorough linting (in rules directory: `python ../scripts/lint.py --thorough -t "<your rule name>" -v .`)
2. you've uploaded each referenced example binary (optional, but greatly appreciated) to https://github.com/mandiant/capa-testfiles

Please mention the issue your PR addresses (if any):
closes #issue_number
-->
