### PR TITLE
extend terminate-process.yml to include exit_group #970

### DIFF
--- a/host-interaction/process/terminate/terminate-process.yml
+++ b/host-interaction/process/terminate/terminate-process.yml
@@ -23,7 +23,9 @@ rule:
       - api: System.Windows.Forms.Application::Exit
       - api: exit
       - api: Exit
-      - api: exit_group
+      - and:
+        - os: linux
+        - api: exit_group
       - and:
         - optional:
           - match: open process

--- a/host-interaction/process/terminate/terminate-process.yml
+++ b/host-interaction/process/terminate/terminate-process.yml
@@ -23,6 +23,7 @@ rule:
       - api: System.Windows.Forms.Application::Exit
       - api: exit
       - api: Exit
+      - api: exit_group
       - and:
         - optional:
           - match: open process


### PR DESCRIPTION
Fixes https://github.com/mandiant/capa-rules/issues/970

[x] No CHANGELOG update needed
[x] No new tests needed
[x] No documentation update needed