### PR TITLE
improve TCP/UDP socket creation matching #964

### DIFF
--- a/communication/socket/tcp/create-tcp-socket.yml
+++ b/communication/socket/tcp/create-tcp-socket.yml
@@ -17,7 +17,9 @@ rule:
   features:
     - or:
       - and:
-        - number: 6 = IPPROTO_TCP
+        - or:
+          - number: 0 = protocol (default)
+          - number: 6 = IPPROTO_TCP
         - number: 1 = SOCK_STREAM
         - number: 2 = AF_INET
         - or:

--- a/communication/socket/tcp/create-tcp-socket.yml
+++ b/communication/socket/tcp/create-tcp-socket.yml
@@ -12,6 +12,9 @@ rule:
       dynamic: call
     mbc:
       - Communication::Socket Communication::Create TCP Socket [C0001.011]
+    references:
+      - https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-socket
+      - https://man7.org/linux/man-pages/man2/socket.2.html
     examples:
       - Practical Malware Analysis Lab 01-01.dll_:0x10001010
   features:

--- a/communication/socket/udp/send/create-udp-socket.yml
+++ b/communication/socket/udp/send/create-udp-socket.yml
@@ -7,7 +7,7 @@ rule:
       - joakim@intezer.com
       - michael.hunhoff@mandiant.com
     scopes:
-      static: function
+      static: basic block
       dynamic: call
     mbc:
       - Communication::Socket Communication::Create UDP Socket [C0001.010]

--- a/communication/socket/udp/send/create-udp-socket.yml
+++ b/communication/socket/udp/send/create-udp-socket.yml
@@ -18,6 +18,8 @@ rule:
       - and:
         - count(number(2 = AF_INET/SOCK_DGRAM)): 2 or more
         - or:
+          - number: 0 = protocol (default)
+        - or:
           - api: socket
           - api: ws2_32.socket
           - api: ws2_32.#23 = socket

--- a/communication/socket/udp/send/create-udp-socket.yml
+++ b/communication/socket/udp/send/create-udp-socket.yml
@@ -22,7 +22,7 @@ rule:
         - or: # Protocol (0 or IPPROTO_UDP=17)
           - number: 0
           - number: 17
-          - bytes: 33 C0 5
+          - bytes: 33 C0 50
         - or:
           - api: socket
           - api: ws2_32.socket

--- a/communication/socket/udp/send/create-udp-socket.yml
+++ b/communication/socket/udp/send/create-udp-socket.yml
@@ -16,13 +16,11 @@ rule:
   features:
     - or:
       - and:
-        - or: # Socket type (AF_INET=2/SOCK_DGRAM=2)
-          - number: 2 = AF_INET
-          - number: 2 = SOCK_DGRAM
+        - number: 2 = AF_INET
+        - number: 2 = SOCK_DGRAM
         - or: # Protocol (0 or IPPROTO_UDP=17)
-          - number: 0
-          - number: 17
-          - bytes: 33 C0 50
+          - number: 0 = protocol (default)
+          - number: 17 = IPPROTO_UDP
         - or:
           - api: socket
           - api: ws2_32.socket

--- a/communication/socket/udp/send/create-udp-socket.yml
+++ b/communication/socket/udp/send/create-udp-socket.yml
@@ -7,7 +7,7 @@ rule:
       - joakim@intezer.com
       - michael.hunhoff@mandiant.com
     scopes:
-      static: basic block
+      static: function
       dynamic: call
     mbc:
       - Communication::Socket Communication::Create UDP Socket [C0001.010]
@@ -16,7 +16,8 @@ rule:
   features:
     - or:
       - and:
-        - count(number(2 = AF_INET/SOCK_DGRAM)): 2 or more
+        - number: 2 = AF_INET
+        - number: 2 = SOCK_DGRAM
         - or:
           - number: 0 = protocol (default)
           - number: 17 = IPPROTO_UDP

--- a/communication/socket/udp/send/create-udp-socket.yml
+++ b/communication/socket/udp/send/create-udp-socket.yml
@@ -16,11 +16,13 @@ rule:
   features:
     - or:
       - and:
-        - number: 2 = AF_INET
-        - number: 2 = SOCK_DGRAM
-        - or:
-          - number: 0 = protocol (default)
-          - number: 17 = IPPROTO_UDP
+        - or: # Socket type (AF_INET=2/SOCK_DGRAM=2)
+          - number: 2 = AF_INET
+          - number: 2 = SOCK_DGRAM
+        - or: # Protocol (0 or IPPROTO_UDP=17)
+          - number: 0
+          - number: 17
+          - bytes: 33 C0 5
         - or:
           - api: socket
           - api: ws2_32.socket

--- a/communication/socket/udp/send/create-udp-socket.yml
+++ b/communication/socket/udp/send/create-udp-socket.yml
@@ -19,6 +19,7 @@ rule:
         - count(number(2 = AF_INET/SOCK_DGRAM)): 2 or more
         - or:
           - number: 0 = protocol (default)
+          - number: 17 = IPPROTO_UDP
         - or:
           - api: socket
           - api: ws2_32.socket

--- a/nursery/create-udp-socket.yml
+++ b/nursery/create-udp-socket.yml
@@ -12,7 +12,7 @@ rule:
     mbc:
       - Communication::Socket Communication::Create UDP Socket [C0001.010]
     examples:
-      - 203BD48BCC18434314AD60F4C8BC21E3D3422EB0624B22B827410F9BC63B4082:0x401240
+      # Have to find a suitable sample for this rule
   features:
     - or:
       - and:

--- a/nursery/create-udp-socket.yml
+++ b/nursery/create-udp-socket.yml
@@ -19,7 +19,7 @@ rule:
       - and:
         - number: 2 = AF_INET
         - number: 2 = SOCK_DGRAM
-        - or: 
+        - or:
           - number: 0 = protocol (default)
           - number: 17 = IPPROTO_UDP
         - or:

--- a/nursery/create-udp-socket.yml
+++ b/nursery/create-udp-socket.yml
@@ -11,14 +11,15 @@ rule:
       dynamic: call
     mbc:
       - Communication::Socket Communication::Create UDP Socket [C0001.010]
-  # examples: # Have to find a suitable sample for this rule
-      #- 203BD48BCC18434314AD60F4C8BC21E3D3422EB0624B22B827410F9BC63B4082:0x401240
+    references:
+      - https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-socket
+      - https://man7.org/linux/man-pages/man2/socket.2.html
   features:
     - or:
       - and:
         - number: 2 = AF_INET
         - number: 2 = SOCK_DGRAM
-        - or: # Protocol (0 or IPPROTO_UDP=17)
+        - or: 
           - number: 0 = protocol (default)
           - number: 17 = IPPROTO_UDP
         - or:

--- a/nursery/create-udp-socket.yml
+++ b/nursery/create-udp-socket.yml
@@ -11,8 +11,8 @@ rule:
       dynamic: call
     mbc:
       - Communication::Socket Communication::Create UDP Socket [C0001.010]
-    examples:
-      # Have to find a suitable sample for this rule
+  # examples: # Have to find a suitable sample for this rule
+      #- 203BD48BCC18434314AD60F4C8BC21E3D3422EB0624B22B827410F9BC63B4082:0x401240
   features:
     - or:
       - and:


### PR DESCRIPTION
Fixes https://github.com/mandiant/capa-rules/issues/964

I have also added number: 17 = IPPROTO_UDP , can make the rule more precise by explicitly matching cases where the UDP protocol is specified. (but not needed specifically)

[x] No CHANGELOG update needed
[x] No new tests needed
[x] No documentation update needed