### PR TITLE
use "span of calls" scope for registry operations that span multiple calls, e.g. open registry key and set value

### DIFF
--- a/nursery/persist-via-aedebug-registry-key.yml
+++ b/nursery/persist-via-aedebug-registry-key.yml
@@ -6,7 +6,7 @@ rule:
       - j.j.vannielen@utwente.nl
     scopes:
       static: function
-      dynamic: call
+      dynamic: span of calls
     att&ck:
       - Persistence::Event Triggered Execution [T1546]
     references:

--- a/nursery/persist-via-amsi-registry-key.yml
+++ b/nursery/persist-via-amsi-registry-key.yml
@@ -6,7 +6,7 @@ rule:
       - j.j.vannielen@utwente.nl
     scopes:
       static: function
-      dynamic: call
+      dynamic: span of calls
     att&ck:
       - Persistence::Event Triggered Execution [T1546]
     references:

--- a/nursery/persist-via-app-paths-registry-key.yml
+++ b/nursery/persist-via-app-paths-registry-key.yml
@@ -6,7 +6,7 @@ rule:
       - j.j.vannielen@utwente.nl
     scopes:
       static: function
-      dynamic: call
+      dynamic: span of calls
     att&ck:
       - Persistence::Hijack Execution Flow::Path Interception by PATH Environment Variable [T1574.007]
     references:

--- a/nursery/persist-via-appcertdlls-registry-key.yml
+++ b/nursery/persist-via-appcertdlls-registry-key.yml
@@ -6,7 +6,7 @@ rule:
       - j.j.vannielen@utwente.nl
     scopes:
       static: function
-      dynamic: call
+      dynamic: span of calls
     att&ck:
       - Persistence::Event Triggered Execution::AppCert DLLs [T1546.009]
     references:

--- a/nursery/persist-via-application-shimming.yml
+++ b/nursery/persist-via-application-shimming.yml
@@ -6,7 +6,7 @@ rule:
       - j.j.vannielen@utwente.nl
     scopes:
       static: function
-      dynamic: call
+      dynamic: span of calls
     att&ck:
       - Persistence::Event Triggered Execution::Application Shimming [T1546.011]
     references:

--- a/nursery/persist-via-appx-registry-key.yml
+++ b/nursery/persist-via-appx-registry-key.yml
@@ -6,7 +6,7 @@ rule:
       - j.j.vannielen@utwente.nl
     scopes:
       static: function
-      dynamic: call
+      dynamic: span of calls
     att&ck:
       - Persistence::Event Triggered Execution [T1546]
     references:

--- a/nursery/persist-via-autodialdll-registry-key.yml
+++ b/nursery/persist-via-autodialdll-registry-key.yml
@@ -6,7 +6,7 @@ rule:
       - j.j.vannielen@utwente.nl
     scopes:
       static: function
-      dynamic: call
+      dynamic: span of calls
     att&ck:
       - Persistence::Event Triggered Execution [T1546]
     references:

--- a/nursery/persist-via-autoplayhandlers-registry-key.yml
+++ b/nursery/persist-via-autoplayhandlers-registry-key.yml
@@ -6,7 +6,7 @@ rule:
       - j.j.vannielen@utwente.nl
     scopes:
       static: function
-      dynamic: call
+      dynamic: span of calls
     att&ck:
       - Persistence::Event Triggered Execution [T1546]
     references:

--- a/nursery/persist-via-bootverificationprogram-registry-key.yml
+++ b/nursery/persist-via-bootverificationprogram-registry-key.yml
@@ -6,7 +6,7 @@ rule:
       - j.j.vannielen@utwente.nl
     scopes:
       static: function
-      dynamic: call
+      dynamic: span of calls
     att&ck:
       - Persistence::Boot or Logon Autostart Execution [T1547]
     references:

--- a/nursery/persist-via-code-signing-registry-key.yml
+++ b/nursery/persist-via-code-signing-registry-key.yml
@@ -6,7 +6,7 @@ rule:
       - j.j.vannielen@utwente.nl
     scopes:
       static: function
-      dynamic: call
+      dynamic: span of calls
     att&ck:
       - Persistence::Event Triggered Execution [T1546]
     references:

--- a/nursery/persist-via-com-hijack.yml
+++ b/nursery/persist-via-com-hijack.yml
@@ -6,7 +6,7 @@ rule:
       - j.j.vannielen@utwente.nl
     scopes:
       static: function
-      dynamic: call
+      dynamic: span of calls
     att&ck:
       - Persistence::Event Triggered Execution::Component Object Model Hijacking [T1546.015]
     references:

--- a/nursery/persist-via-command-processor-registry-key.yml
+++ b/nursery/persist-via-command-processor-registry-key.yml
@@ -6,7 +6,7 @@ rule:
       - j.j.vannielen@utwente.nl
     scopes:
       static: function
-      dynamic: call
+      dynamic: span of calls
     att&ck:
       - Persistence::Event Triggered Execution [T1546]
     references:

--- a/nursery/persist-via-contextmenuhandlers-registry-key.yml
+++ b/nursery/persist-via-contextmenuhandlers-registry-key.yml
@@ -6,7 +6,7 @@ rule:
       - j.j.vannielen@utwente.nl
     scopes:
       static: function
-      dynamic: call
+      dynamic: span of calls
     att&ck:
       - Persistence::Event Triggered Execution [T1546]
     references:

--- a/nursery/persist-via-cor_profiler_path-registry-value.yml
+++ b/nursery/persist-via-cor_profiler_path-registry-value.yml
@@ -6,7 +6,7 @@ rule:
       - j.j.vannielen@utwente.nl
     scopes:
       static: function
-      dynamic: call
+      dynamic: span of calls
     att&ck:
       - Persistence::Hijack Execution Flow::COR_PROFILER [T1574.012]
     references:

--- a/nursery/persist-via-default-file-association-registry-key.yml
+++ b/nursery/persist-via-default-file-association-registry-key.yml
@@ -6,7 +6,7 @@ rule:
       - j.j.vannielen@utwente.nl
     scopes:
       static: function
-      dynamic: call
+      dynamic: span of calls
     att&ck:
       - Persistence::Event Triggered Execution::Change Default File Association [T1546.001]
     references:

--- a/nursery/persist-via-disk-cleanup-handler-registry-key.yml
+++ b/nursery/persist-via-disk-cleanup-handler-registry-key.yml
@@ -6,7 +6,7 @@ rule:
       - j.j.vannielen@utwente.nl
     scopes:
       static: function
-      dynamic: call
+      dynamic: span of calls
     att&ck:
       - Persistence::Event Triggered Execution [T1546]
     references:

--- a/nursery/persist-via-dotnet-dbgmanageddebugger-registry-key.yml
+++ b/nursery/persist-via-dotnet-dbgmanageddebugger-registry-key.yml
@@ -6,7 +6,7 @@ rule:
       - j.j.vannielen@utwente.nl
     scopes:
       static: function
-      dynamic: call
+      dynamic: span of calls
     att&ck:
       - Persistence::Event Triggered Execution [T1546]
     references:

--- a/nursery/persist-via-dotnet_startup_hooks-registry-key.yml
+++ b/nursery/persist-via-dotnet_startup_hooks-registry-key.yml
@@ -6,7 +6,7 @@ rule:
       - j.j.vannielen@utwente.nl
     scopes:
       static: function
-      dynamic: call
+      dynamic: span of calls
     att&ck:
       - Persistence::Hijack Execution Flow::DLL Side-Loading [T1574.002]
     references:

--- a/nursery/persist-via-explorer-tools-registry-key.yml
+++ b/nursery/persist-via-explorer-tools-registry-key.yml
@@ -6,7 +6,7 @@ rule:
       - j.j.vannielen@utwente.nl
     scopes:
       static: function
-      dynamic: call
+      dynamic: span of calls
     att&ck:
       - Persistence::Event Triggered Execution [T1546]
     references:

--- a/nursery/persist-via-filter-handlers-registry-key.yml
+++ b/nursery/persist-via-filter-handlers-registry-key.yml
@@ -6,7 +6,7 @@ rule:
       - j.j.vannielen@utwente.nl
     scopes:
       static: function
-      dynamic: call
+      dynamic: span of calls
     att&ck:
       - Persistence::Event Triggered Execution [T1546]
     references:

--- a/nursery/persist-via-group-policy-registry-key.yml
+++ b/nursery/persist-via-group-policy-registry-key.yml
@@ -6,7 +6,7 @@ rule:
       - j.j.vannielen@utwente.nl
     scopes:
       static: function
-      dynamic: call
+      dynamic: span of calls
     att&ck:
       - Persistence::Boot or Logon Autostart Execution [T1547]
     references:

--- a/nursery/persist-via-hhctrl-com-hijack.yml
+++ b/nursery/persist-via-hhctrl-com-hijack.yml
@@ -6,7 +6,7 @@ rule:
       - j.j.vannielen@utwente.nl
     scopes:
       static: function
-      dynamic: call
+      dynamic: span of calls
     att&ck:
       - Persistence::Hijack Execution Flow [T1574]
     references:

--- a/nursery/persist-via-htmlhelp-author-registry-key.yml
+++ b/nursery/persist-via-htmlhelp-author-registry-key.yml
@@ -6,7 +6,7 @@ rule:
       - j.j.vannielen@utwente.nl
     scopes:
       static: function
-      dynamic: call
+      dynamic: span of calls
     att&ck:
       - Persistence::Hijack Execution Flow [T1574]
     references:

--- a/nursery/persist-via-image-file-execution-options-registry-key.yml
+++ b/nursery/persist-via-image-file-execution-options-registry-key.yml
@@ -6,7 +6,7 @@ rule:
       - j.j.vannielen@utwente.nl
     scopes:
       static: function
-      dynamic: call
+      dynamic: span of calls
     att&ck:
       - Persistence::Event Triggered Execution::Image File Execution Options Injection [T1546.012]
     references:

--- a/nursery/persist-via-lsa-registry-key.yml
+++ b/nursery/persist-via-lsa-registry-key.yml
@@ -6,7 +6,7 @@ rule:
       - j.j.vannielen@utwente.nl
     scopes:
       static: function
-      dynamic: call
+      dynamic: span of calls
     att&ck:
       - Persistence::Boot or Logon Autostart Execution::Authentication Package [T1547.002]
       - Persistence::Boot or Logon Autostart Execution::Security Support Provider [T1547.005]

--- a/nursery/persist-via-natural-language-registry-key.yml
+++ b/nursery/persist-via-natural-language-registry-key.yml
@@ -6,7 +6,7 @@ rule:
       - j.j.vannielen@utwente.nl
     scopes:
       static: function
-      dynamic: call
+      dynamic: span of calls
     att&ck:
       - Persistence::Boot or Logon Autostart Execution [T1547]
     references:

--- a/nursery/persist-via-netsh-registry-key.yml
+++ b/nursery/persist-via-netsh-registry-key.yml
@@ -6,7 +6,7 @@ rule:
       - j.j.vannielen@utwente.nl
     scopes:
       static: function
-      dynamic: call
+      dynamic: span of calls
     att&ck:
       - Persistence::Event Triggered Execution [T1546]
     references:

--- a/nursery/persist-via-network-provider-registry-key.yml
+++ b/nursery/persist-via-network-provider-registry-key.yml
@@ -6,7 +6,7 @@ rule:
       - j.j.vannielen@utwente.nl
     scopes:
       static: function
-      dynamic: call
+      dynamic: span of calls
     att&ck:
       - Persistence::Modify Authentication Process::Network Provider DLL [T1556.008]
     references:

--- a/nursery/persist-via-path-registry-key.yml
+++ b/nursery/persist-via-path-registry-key.yml
@@ -6,7 +6,7 @@ rule:
       - j.j.vannielen@utwente.nl
     scopes:
       static: function
-      dynamic: call
+      dynamic: span of calls
     att&ck:
       - Persistence::Hijack Execution Flow::Path Interception by PATH Environment Variable [T1574.007]
     references:

--- a/nursery/persist-via-print-monitors-registry-key.yml
+++ b/nursery/persist-via-print-monitors-registry-key.yml
@@ -6,7 +6,7 @@ rule:
       - j.j.vannielen@utwente.nl
     scopes:
       static: function
-      dynamic: call
+      dynamic: span of calls
     att&ck:
       - Persistence::Boot or Logon Autostart Execution::Port Monitors [T1547.010]
     references:

--- a/nursery/persist-via-print-processors-registry-key.yml
+++ b/nursery/persist-via-print-processors-registry-key.yml
@@ -6,7 +6,7 @@ rule:
       - j.j.vannielen@utwente.nl
     scopes:
       static: function
-      dynamic: call
+      dynamic: span of calls
     att&ck:
       - Persistence::Boot or Logon Autostart Execution::Print Processors [T1547.012]
     references:

--- a/nursery/persist-via-rdp-startup-programs-registry-key.yml
+++ b/nursery/persist-via-rdp-startup-programs-registry-key.yml
@@ -6,7 +6,7 @@ rule:
       - j.j.vannielen@utwente.nl
     scopes:
       static: function
-      dynamic: call
+      dynamic: span of calls
     att&ck:
       - Persistence::Event Triggered Execution [T1546]
     references:

--- a/nursery/persist-via-screensaver-registry-key.yml
+++ b/nursery/persist-via-screensaver-registry-key.yml
@@ -7,7 +7,7 @@ rule:
     description: SCRNSAVE.EXE registry value specifies the name of the screen saver executable file
     scopes:
       static: function
-      dynamic: call
+      dynamic: span of calls
     att&ck:
       - Persistence::Event Triggered Execution::Screensaver [T1546.002]
   features:

--- a/nursery/persist-via-silentprocessexit-registry-key.yml
+++ b/nursery/persist-via-silentprocessexit-registry-key.yml
@@ -6,7 +6,7 @@ rule:
       - j.j.vannielen@utwente.nl
     scopes:
       static: function
-      dynamic: call
+      dynamic: span of calls
     att&ck:
       - Persistence::Event Triggered Execution [T1546]
     references:

--- a/nursery/persist-via-telemetrycontroller-registry-key.yml
+++ b/nursery/persist-via-telemetrycontroller-registry-key.yml
@@ -6,7 +6,7 @@ rule:
       - j.j.vannielen@utwente.nl
     scopes:
       static: function
-      dynamic: call
+      dynamic: span of calls
     att&ck:
       - Persistence::Scheduled Task/Job [T1053]
     references:

--- a/nursery/persist-via-timeproviders-registry-key.yml
+++ b/nursery/persist-via-timeproviders-registry-key.yml
@@ -6,7 +6,7 @@ rule:
       - j.j.vannielen@utwente.nl
     scopes:
       static: function
-      dynamic: call
+      dynamic: span of calls
     att&ck:
       - Persistence::Boot or Logon Autostart Execution::Time Providers [T1547.003]
     references:

--- a/nursery/persist-via-ts-initialprogram-registry-key.yml
+++ b/nursery/persist-via-ts-initialprogram-registry-key.yml
@@ -6,7 +6,7 @@ rule:
       - j.j.vannielen@utwente.nl
     scopes:
       static: function
-      dynamic: call
+      dynamic: span of calls
     att&ck:
       - Persistence::Event Triggered Execution [T1546]
     references:

--- a/nursery/persist-via-userinitmprlogonscript-registry-value.yml
+++ b/nursery/persist-via-userinitmprlogonscript-registry-value.yml
@@ -6,7 +6,7 @@ rule:
       - j.j.vannielen@utwente.nl
     scopes:
       static: function
-      dynamic: call
+      dynamic: span of calls
     att&ck:
       - Persistence::Boot or Logon Initialization Scripts::Logon Script (Windows) [T1037.001]
     references:

--- a/nursery/persist-via-windows-error-reporting-registry-key.yml
+++ b/nursery/persist-via-windows-error-reporting-registry-key.yml
@@ -6,7 +6,7 @@ rule:
       - j.j.vannielen@utwente.nl
     scopes:
       static: function
-      dynamic: call
+      dynamic: span of calls
     att&ck:
       - Persistence::Event Triggered Execution [T1546]
     references:

--- a/persistence/registry/appinitdlls/persist-via-appinit_dlls-registry-key.yml
+++ b/persistence/registry/appinitdlls/persist-via-appinit_dlls-registry-key.yml
@@ -6,7 +6,7 @@ rule:
       - michael.hunhoff@fireye.com
     scopes:
       static: function
-      dynamic: call
+      dynamic: span of calls
     att&ck:
       - Persistence::Event Triggered Execution::AppInit DLLs [T1546.010]
     references:

--- a/persistence/registry/ginadll/persist-via-ginadll-registry-key.yml
+++ b/persistence/registry/ginadll/persist-via-ginadll-registry-key.yml
@@ -6,7 +6,7 @@ rule:
       - michael.hunhoff@fireye.com
     scopes:
       static: function
-      dynamic: call
+      dynamic: span of calls
     att&ck:
       - Persistence::Event Triggered Execution [T1546]
     examples:

--- a/persistence/registry/persist-via-active-setup-registry-key.yml
+++ b/persistence/registry/persist-via-active-setup-registry-key.yml
@@ -6,7 +6,7 @@ rule:
       - moritz.raabe@mandiant.com
     scopes:
       static: function
-      dynamic: call
+      dynamic: span of calls
     att&ck:
       - Persistence::Boot or Logon Autostart Execution::Active Setup [T1547.014]
     references:

--- a/persistence/registry/run/persist-via-run-registry-key.yml
+++ b/persistence/registry/run/persist-via-run-registry-key.yml
@@ -6,7 +6,7 @@ rule:
       - moritz.raabe@mandiant.com
     scopes:
       static: function
-      dynamic: call
+      dynamic: span of calls
     att&ck:
       - Persistence::Boot or Logon Autostart Execution::Registry Run Keys / Startup Folder [T1547.001]
     mbc:

--- a/persistence/registry/winlogon-helper/persist-via-winlogon-helper-dll-registry-key.yml
+++ b/persistence/registry/winlogon-helper/persist-via-winlogon-helper-dll-registry-key.yml
@@ -7,7 +7,7 @@ rule:
       - j.j.vannielen@utwente.nl
     scopes:
       static: function
-      dynamic: call
+      dynamic: span of calls
     att&ck:
       - Persistence::Boot or Logon Autostart Execution::Winlogon Helper DLL [T1547.004]
     references:

--- a/persistence/scheduled-tasks/schedule-task-via-schtasks.yml
+++ b/persistence/scheduled-tasks/schedule-task-via-schtasks.yml
@@ -7,7 +7,7 @@ rule:
       - j.j.vannielen@utwente.nl
     scopes:
       static: function
-      dynamic: call
+      dynamic: span of calls
     att&ck:
       - Persistence::Scheduled Task/Job::Scheduled Task [T1053.005]
     references:

--- a/persistence/service/persist-via-windows-service.yml
+++ b/persistence/service/persist-via-windows-service.yml
@@ -6,7 +6,7 @@ rule:
       - moritz.raabe@mandiant.com
     scopes:
       static: function
-      dynamic: call
+      dynamic: span of calls
     att&ck:
       - Persistence::Create or Modify System Process::Windows Service [T1543.003]
       - Execution::System Services::Service Execution [T1569.002]
@@ -38,5 +38,5 @@ rule:
           - string: /^sc(|\.exe) create/i
           - string: /New-Service /i
       - and:
-        - match: "set registry value"
+        - match: set registry value
         - string: /System\\(CurrentControlSet|ControlSet001)\\Services/i


### PR DESCRIPTION
see original concerned expressed [here](https://github.com/mandiant/capa-rules/pull/954#pullrequestreview-2482035858).