### PR TITLE
Create get-domain-admins.yml

### DIFF
--- a/nursery/get-domain-admins.yml
+++ b/nursery/get-domain-admins.yml
@@ -1,0 +1,19 @@
+rule:
+  meta:
+    name: get domain admins
+    namespace: collection/network
+    authors:
+      - kevross33/Kevin Ross
+    scopes:
+      static: function
+      dynamic: span of calls
+    att&ck:
+      - Discovery::Permission Groups Discovery [T1069]
+    examples:
+      - f5fca1b178af87bd48c7ea9e3f2c957b
+  features:
+    - and:
+      - string: /net/i
+      - string: /group/i
+      - string: /domain admins/i
+      - string: //domain/i


### PR DESCRIPTION
Create signature for samples executing net group "domain admins" /domain i..e SHA256 47e9917ce0afc96632db5e95db2fd9aff10d05b0399fd05d02035eacb3c1f399


<!--
Thank you for contributing to capa! <3

Please ensure that:
1. each rule passes thorough linting (in rules directory: `python ../scripts/lint.py --thorough -t "<your rule name>" -v .`)
2. you've uploaded each referenced example binary (optional, but greatly appreciated) to https://github.com/mandiant/capa-testfiles

Please mention the issue your PR addresses (if any):
closes #issue_number
-->
