### PR TITLE
Create wmi-get-antivirus.yml

### DIFF
--- a/nursery/wmi-get-antivirus.yml
+++ b/nursery/wmi-get-antivirus.yml
@@ -1,0 +1,17 @@
+rule:
+  meta:
+    name: wmi get antivirus
+    namespace: collection/anti-virus
+    authors:
+      - kevross33/Kevin Ross
+    scopes:
+      static: function
+      dynamic: span of calls
+    att&ck:
+      - Discovery::Permission Groups Discovery [T1069]
+    examples:
+      - f5fca1b178af87bd48c7ea9e3f2c957b
+  features:
+    - and:
+      - string: /root\\securitycenter/i
+      - string: /antivirusproduct/i


### PR DESCRIPTION
Rule to detect querying installed anti-virus via WMI


<!--
Thank you for contributing to capa! <3

Please ensure that:
1. each rule passes thorough linting (in rules directory: `python ../scripts/lint.py --thorough -t "<your rule name>" -v .`)
2. you've uploaded each referenced example binary (optional, but greatly appreciated) to https://github.com/mandiant/capa-testfiles

Please mention the issue your PR addresses (if any):
closes #issue_number
-->
