### PR TITLE
tighten "persist via run registry key" to reduce FPs

### DIFF
--- a/persistence/registry/run/persist-via-run-registry-key.yml
+++ b/persistence/registry/run/persist-via-run-registry-key.yml
@@ -4,6 +4,7 @@ rule:
     namespace: persistence/registry/run
     authors:
       - moritz.raabe@mandiant.com
+      - mehunhoff@google.com
     scopes:
       static: function
       dynamic: span of calls
@@ -17,20 +18,16 @@ rule:
       - 9ff8e68343cc29c1036650fc153e69f7:0x470624
   features:
     - and:
-      - or:
+      - and:
         - match: set registry value
-        - number: 0x80000001 = HKEY_CURRENT_USER
-        - number: 0x80000002 = HKEY_LOCAL_MACHINE
+        - or:
+          - number: 0x80000001 = HKEY_CURRENT_USER
+          - number: 0x80000002 = HKEY_LOCAL_MACHINE
       - or:
-        - and:
-          - string: /Software\\Microsoft\\Windows\\CurrentVersion/i
-          - or:
-            - string: /Run/i
-            - string: /Explorer\\Shell Folders/i
-            - string: /User Shell Folders/i
-            - string: /RunServices/i
-            - string: /Policies\\Explorer\\Run/i
-        - and:
-          - string: /Software\\Microsoft\\Windows NT\\CurrentVersion\\Windows/i
-          - string: /Load/i
+        - string: /Software\\Microsoft\\Windows\\CurrentVersion\\Run/i
+        - string: /Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Shell Folders/i
+        - string: /Software\\Microsoft\\Windows\\CurrentVersion\\User Shell Folders/i
+        - string: /Software\\Microsoft\\Windows\\CurrentVersion\\RunServices/i
+        - string: /Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\Explorer\\Run/i
+        - string: /Software\\Microsoft\\Windows NT\\CurrentVersion\\Windows\\Load/i
         - string: /System\\CurrentControlSet\\Control\\Session Manager\\BootExecute/i

--- a/persistence/registry/run/persist-via-run-registry-key.yml
+++ b/persistence/registry/run/persist-via-run-registry-key.yml
@@ -18,11 +18,10 @@ rule:
       - 9ff8e68343cc29c1036650fc153e69f7:0x470624
   features:
     - and:
-      - and:
+      - or:
         - match: set registry value
-        - or:
-          - number: 0x80000001 = HKEY_CURRENT_USER
-          - number: 0x80000002 = HKEY_LOCAL_MACHINE
+        - number: 0x80000001 = HKEY_CURRENT_USER
+        - number: 0x80000002 = HKEY_LOCAL_MACHINE
       - or:
         - string: /Software\\Microsoft\\Windows\\CurrentVersion\\Run/i
         - string: /Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Shell Folders/i


### PR DESCRIPTION
I'm seeing quite a few FPs because of the previous `string(/Run/i)` feature, e.g., the sandbox run for a sample I'm looking at contains many references to `Bruno` in various file paths, which are triggering this rule to match. I've opted to be explicit about the registry key matches to reduce FPs. 