### PR TITLE
Addresses #965: Create separate rules for socket connects (TCP/UDP)

### DIFF
--- a/communication/socket/connect-socket.yml
+++ b/communication/socket/connect-socket.yml
@@ -1,0 +1,71 @@
+rule:
+  meta:
+    name: connect socket
+    namespace: communication/socket
+    authors:
+      - moritz.raabe@mandiant.com
+      - joakim@intezer.com
+      - mrhafizfarhad@gmail.com
+    description: >
+      Detects socket connection attempts using common APIs or ConnectEx setup.
+    scopes:
+      static: basic block
+      dynamic: span of calls
+    examples:
+      - Practical Malware Analysis Lab 01-01.dll_:0x10001010
+  features:
+    - or:
+      - api: connect
+      - api: ws2_32.connect
+      - api: ws2_32.#4 = connect
+      - api: ws2_32.WSAConnect
+      - api: ws2_32.#33 = WSAConnect
+      - api: ConnectEx
+      - or:
+        - and:
+          # static
+          - basic block:
+            # candidate for GUID: WSAID_CONNECTEX/25a207b9-ddf3-4660-8ee9-76e58c74063e
+            - and:
+              - number: 0x25A207B9
+              - number: 0x4660DDF3
+              - number: 0xE576E98E
+              - number: 0x3E06748C
+          - basic block:
+            - and:
+              - or:
+                - api: ws2_32.WSAIoctl
+                - api: ws2_32.#60 = WSAIoctl
+              - number: 0xC8000006 = SIO_GET_EXTENSION_FUNCTION_POINTER
+          - basic block:
+            - and:
+              - or:
+                - api: setsockopt
+                - api: ws2_32.#21 = setsockopt
+              - number: 0xFFFF = SOL_SOCKET
+              - number: 0x7010 = SO_UPDATE_CONNECT_CONTEXT
+          # socket must be bound to ConnectEx
+          # https://gist.github.com/joeyadams/4158972
+          - or:
+            - api: bind
+            - api: ws2_32.#2 = bind
+        - and:
+          # dynamic
+          - call:
+            - and:
+              - or:
+                - api: ws2_32.WSAIoctl
+                - api: ws2_32.#60 = WSAIoctl
+              - number: 0xC8000006 = SIO_GET_EXTENSION_FUNCTION_POINTER
+          - call:
+            - and:
+              - or:
+                - api: setsockopt
+                - api: ws2_32.#21 = setsockopt
+              - number: 0xFFFF = SOL_SOCKET
+              - number: 0x7010 = SO_UPDATE_CONNECT_CONTEXT
+          # socket must be bound to ConnectEx
+          # https://gist.github.com/joeyadams/4158972
+          - or:
+            - api: bind
+            - api: ws2_32.#2 = bind

--- a/communication/socket/connect-socket.yml
+++ b/communication/socket/connect-socket.yml
@@ -6,8 +6,7 @@ rule:
       - moritz.raabe@mandiant.com
       - joakim@intezer.com
       - mrhafizfarhad@gmail.com
-    description: >
-      Detects socket connection attempts using common APIs or ConnectEx setup.
+    description: Detects socket connection attempts using common APIs or ConnectEx setup.
     scopes:
       static: basic block
       dynamic: span of calls

--- a/communication/socket/tcp/connect-tcp-socket.yml
+++ b/communication/socket/tcp/connect-tcp-socket.yml
@@ -5,6 +5,7 @@ rule:
     authors:
       - moritz.raabe@mandiant.com
       - joakim@intezer.com
+      - mrhafizfarhad@gmail.com
     scopes:
       static: function
       dynamic: span of calls
@@ -14,59 +15,5 @@ rule:
       - Practical Malware Analysis Lab 01-01.dll_:0x10001010
   features:
     - and:
-      - match: create TCP socket
-      - or:
-        - api: connect
-        - api: ws2_32.connect
-        - api: ws2_32.#4 = connect
-        - api: ws2_32.WSAConnect
-        - api: ws2_32.#33 = WSAConnect
-        - api: ConnectEx
-        - or:
-          - and:
-            # static
-            - basic block:
-              # candidate for GUID: WSAID_CONNECTEX/25a207b9-ddf3-4660-8ee9-76e58c74063e
-              - and:
-                - number: 0x25A207B9
-                - number: 0x4660DDF3
-                - number: 0xE576E98E
-                - number: 0x3E06748C
-            - basic block:
-              - and:
-                - or:
-                  - api: ws2_32.WSAIoctl
-                  - api: ws2_32.#60 = WSAIoctl
-                - number: 0xC8000006 = SIO_GET_EXTENSION_FUNCTION_POINTER
-            - basic block:
-              - and:
-                - or:
-                  - api: setsockopt
-                  - api: ws2_32.#21 = setsockopt
-                - number: 0xFFFF = SOL_SOCKET
-                - number: 0x7010 = SO_UPDATE_CONNECT_CONTEXT
-            # socket must be bound to ConnectEx
-            # https://gist.github.com/joeyadams/4158972
-            - or:
-              - api: bind
-              - api: ws2_32.#2 = bind
-          - and:
-            # dynamic
-            - call:
-              - and:
-                - or:
-                  - api: ws2_32.WSAIoctl
-                  - api: ws2_32.#60 = WSAIoctl
-                - number: 0xC8000006 = SIO_GET_EXTENSION_FUNCTION_POINTER
-            - call:
-              - and:
-                - or:
-                  - api: setsockopt
-                  - api: ws2_32.#21 = setsockopt
-                - number: 0xFFFF = SOL_SOCKET
-                - number: 0x7010 = SO_UPDATE_CONNECT_CONTEXT
-            # socket must be bound to ConnectEx
-            # https://gist.github.com/joeyadams/4158972
-            - or:
-              - api: bind
-              - api: ws2_32.#2 = bind
+      - match: create UDP socket
+      - match: connect socket

--- a/communication/socket/tcp/connect-tcp-socket.yml
+++ b/communication/socket/tcp/connect-tcp-socket.yml
@@ -15,5 +15,5 @@ rule:
       - Practical Malware Analysis Lab 01-01.dll_:0x10001010
   features:
     - and:
-      - match: create UDP socket
+      - match: create TCP socket
       - match: connect socket

--- a/communication/socket/udp/connect-udp-socket.yml
+++ b/communication/socket/udp/connect-udp-socket.yml
@@ -1,0 +1,17 @@
+rule:
+  meta:
+    name: connect UDP socket
+    namespace: communication/socket/udp
+    authors:
+      - mrhafizfarhad@gmail.com
+    description: >
+      Detects UDP socket connections by combining UDP socket creation with connection attempts.
+    scopes:
+      static: function
+      dynamic: span of calls
+    mbc:
+      - Communication::Socket Communication::UDP Client [C0001.013]
+  features:
+    - and:
+      - match: create UDP socket
+      - match: connect socket

--- a/communication/socket/udp/connect-udp-socket.yml
+++ b/communication/socket/udp/connect-udp-socket.yml
@@ -4,8 +4,7 @@ rule:
     namespace: communication/socket/udp
     authors:
       - mrhafizfarhad@gmail.com
-    description: >
-      Detects UDP socket connections by combining UDP socket creation with connection attempts.
+    description: Detects UDP socket connections by combining UDP socket creation with connection attempts.
     scopes:
       static: function
       dynamic: span of calls

--- a/communication/socket/udp/connect-udp-socket.yml
+++ b/communication/socket/udp/connect-udp-socket.yml
@@ -11,6 +11,8 @@ rule:
       dynamic: span of calls
     mbc:
       - Communication::Socket Communication::UDP Client [C0001.013]
+    examples:
+      - 368239d36d221d8877a07ab6799e643a.elf_:0x20011E9
   features:
     - and:
       - match: create UDP socket


### PR DESCRIPTION
- Add a generic `connect socket` rule capturing common connection APIs.
- Refactor the TCP connect rule to require a match on `create TCP socket` and the  `connect socket` rule
- Add a new UDP connect rule that requires a match on `create UDP socket` and the  `connect socket` rule.

Closes #965.


<!--
Thank you for contributing to capa! <3

Please ensure that:
1. each rule passes thorough linting (in rules directory: `python ../scripts/lint.py --thorough -t "<your rule name>" -v .`)
2. you've uploaded each referenced example binary (optional, but greatly appreciated) to https://github.com/mandiant/capa-testfiles

Please mention the issue your PR addresses (if any):
closes #issue_number
-->
