### PR TITLE
Fix 'clear Windows event logs remotely'

### DIFF
--- a/anti-analysis/anti-forensic/clear-logs/clear-windows-event-logs-remotely.yml
+++ b/anti-analysis/anti-forensic/clear-logs/clear-windows-event-logs-remotely.yml
@@ -16,5 +16,4 @@ rule:
   features:
     - and:
       - api: wevtapi.EvtOpenSession
-      - api: wevtapi.EvtOpenLog
       - api: wevtapi.EvtClearLog


### PR DESCRIPTION
Removed EvtOpenLog from the logic, as it is not required for EvtClearLog (the only handle the function can receive is a session handle which is optional and required only for remote operation)
![image](https://github.com/user-attachments/assets/2371555f-72ad-4c16-9dfc-91bf17d15aa8)
