### PR TITLE
Fix 'clear Windows event logs remotely'

### DIFF
--- a/anti-analysis/anti-forensic/clear-logs/clear-windows-event-logs-remotely.yml
+++ b/anti-analysis/anti-forensic/clear-logs/clear-windows-event-logs-remotely.yml
@@ -16,5 +16,4 @@ rule:
   features:
     - and:
       - api: wevtapi.EvtOpenSession
-      - api: wevtapi.EvtOpenLog
       - api: wevtapi.EvtClearLog


### PR DESCRIPTION
EvtOpenLog has been removed from the logic since it is unnecessary for EvtClearLog. The only handle EvtClearLog can accept is a session handle (acquired by EvtOpenSession), which is optional and only needed for remote operations.
![image](https://github.com/user-attachments/assets/836ac225-37a1-49e6-89c1-acc2437fa958)
