### PR TITLE
  detect usage of TripleDesCryptoServiceProvider

### DIFF
--- a/nursery/encrypt-data-using-TripleDESCryptoServiceProvider.yml
+++ b/nursery/encrypt-data-using-TripleDESCryptoServiceProvider.yml
@@ -1,0 +1,20 @@
+rule:
+  meta:
+    name: encrypt data using TripleDESCryptoServiceProvider
+    namespace: data-manipulation/encryption/des
+    authors:
+      - "0xRavenspar"
+    scopes:
+      static: file
+      dynamic: span of calls
+    att&ck:
+      - Defense Evasion::Obfuscated Files or Information [T1027]
+    mbc:
+      - Defense Evasion::Obfuscated Files or Information::Encryption-Standard Algorithm [E1027.m05]
+      - Cryptography::Encrypt Data::3DES [C0027.004]
+    examples:
+      - e71618ae5f1a67d90490be62796854ee
+  features:
+    - or:
+      - string: "TripleDESCryptoServiceProvider"
+      - api: System.Security.Cryptography.TripleDESCryptoServiceProvider

--- a/nursery/encrypt-data-using-tripledes-via-dotnetapi.yml
+++ b/nursery/encrypt-data-using-tripledes-via-dotnetapi.yml
@@ -1,22 +1,20 @@
 rule:
   meta:
-    name: use of TripleDESCryptoServiceProvider
+    name: encrypt data using tripleDES via dotnetapi
     namespace: data-manipulation/encryption/des
     authors:
       - "0xRavenspar"
-    scopes: 
+    scopes:
       static: file
       dynamic: span of calls
     att&ck:
       - Defense Evasion::Obfuscated Files or Information [T1027]
-    mbc: 
+    mbc:
       - Defense Evasion::Obfuscated Files or Information::Encryption-Standard Algorithm [E1027.m05]
       - Cryptography::Encrypt Data::3DES [C0027.004]
+    examples:
+      - e71618ae5f1a67d90490be62796854ee
   features:
     - or:
-      - string: "System.Security.Cryptography.TripleDESCryptoServiceProvider"
       - string: "TripleDESCryptoServiceProvider"
-      - string: "new TripleDESCryptoServiceProvider"
       - api: System.Security.Cryptography.TripleDESCryptoServiceProvider
-        
-

--- a/nursery/triple-des-dotnet.yml
+++ b/nursery/triple-des-dotnet.yml
@@ -1,0 +1,22 @@
+rule:
+  meta:
+    name: use of TripleDESCryptoServiceProvider
+    namespace: data-manipulation/encryption/des
+    authors:
+      - "0xRavenspar"
+    scopes: 
+      static: file
+      dynamic: span of calls
+    att&ck:
+      - Defense Evasion::Obfuscated Files or Information [T1027]
+    mbc: 
+      - Defense Evasion::Obfuscated Files or Information::Encryption-Standard Algorithm [E1027.m05]
+      - Cryptography::Encrypt Data::3DES [C0027.004]
+  features:
+    - or:
+      - string: "System.Security.Cryptography.TripleDESCryptoServiceProvider"
+      - string: "TripleDESCryptoServiceProvider"
+      - string: "new TripleDESCryptoServiceProvider"
+      - api: System.Security.Cryptography.TripleDESCryptoServiceProvider
+        
+


### PR DESCRIPTION
This PR adds a signature to detect usage of TripleDESCryptoServiceProvider class in dotnet executables. 

Closes #957 