### PR TITLE
Update manipulate-boot-configuration.yml

### DIFF
--- a/host-interaction/bootloader/manipulate-boot-configuration.yml
+++ b/host-interaction/bootloader/manipulate-boot-configuration.yml
@@ -14,11 +14,11 @@ rule:
   features:
     - or:
       - and:
-        - string: /bcdedit.exe/i
+        - string: /bcdedit\.exe/i
         - optional:
           - string: "/deletevalue safeboot"
       - and:
-        - string: /boot.ini/i
+        - string: /boot\.ini/i
         - optional:
           - api: kernel32.GetPrivateProfileStringA
           - api: kernel32.WritePrivateProfileString


### PR DESCRIPTION
Escaping dots in regex is important

![image](https://github.com/user-attachments/assets/84d8b3fd-2fc2-4def-ab88-599632183562)