### PR TITLE
remove FPs from allocate-or-change-rwx-memory.yml

### DIFF
--- a/host-interaction/process/inject/allocate-or-change-rwx-memory.yml
+++ b/host-interaction/process/inject/allocate-or-change-rwx-memory.yml
@@ -4,9 +4,10 @@ rule:
     namespace: host-interaction/process/inject
     authors:
       - "@mr-tz"
+      - mehunhoff@google.com
     scopes:
       static: basic block
-      dynamic: span of calls
+      dynamic: call
     mbc:
       - Memory::Allocate Memory [C0007]
     examples:
@@ -14,14 +15,22 @@ rule:
       # ntdll
       - 563653399B82CD443F120ECEFF836EA3678D4CF11D9B351BB737573C2D856299:0x140001ABA
   features:
-    - and:
-      - or:
-        - match: allocate memory
-        - match: change memory protection
-      - or:
-        - number: 0x40 = PAGE_EXECUTE_READWRITE
-        # lea     r9d, [rcx+40h]  ; flProtect
-        # call    cs:VirtualAlloc
-        - instruction:
-          - mnemonic: lea
-          - offset: 0x40 = PAGE_EXECUTE_READWRITE
+    - or:
+      - basic block:
+        - and:
+          - or:
+            - match: allocate memory
+            - match: change memory protection
+          - or:
+            - number: 0x40 = PAGE_EXECUTE_READWRITE
+            # lea     r9d, [rcx+40h]  ; flProtect
+            # call    cs:VirtualAlloc
+            - instruction:
+              - mnemonic: lea
+              - offset: 0x40 = PAGE_EXECUTE_READWRITE
+      - call:
+        - and:
+          - or:
+            - match: allocate memory
+            - match: change memory protection
+          - number: 0x40 = PAGE_EXECUTE_READWRITE


### PR DESCRIPTION
I'm seeing many FPs for dynamic runs when matching constant `0x40` using _span of calls_ scope. This reduces dynamic scope to _call_ and splits matching across static (_basic block_ scope) and dynamic (_call_ scope).