### PR TITLE
add more APIs to "link function at runtime on Windows" to remove FNs

### DIFF
--- a/linking/runtime-linking/link-function-at-runtime-on-windows.yml
+++ b/linking/runtime-linking/link-function-at-runtime-on-windows.yml
@@ -4,7 +4,7 @@ rule:
     namespace: linking/runtime-linking
     authors:
       - moritz.raabe@mandiant.com
-      - michael.hunhoff@mandiant.com
+      - mehunhoff@google.com
     scopes:
       static: instruction
       dynamic: call
@@ -19,3 +19,6 @@ rule:
       - or:
         - api: kernel32.GetProcAddress
         - api: ntdll.LdrGetProcedureAddress
+        - api: ntdll.LdrGetProcedureAddressEx
+        - api: ntdll.LdrGetProcedureAddressForCaller
+        - api: MmGetSystemRoutineAddress


### PR DESCRIPTION
adding APIs found in ITW CAPE reports