### PR TITLE
add APIs to mutex-related rules on Windows to reduce FNs

### DIFF
--- a/host-interaction/mutex/check-mutex-on-windows.yml
+++ b/host-interaction/mutex/check-mutex-on-windows.yml
@@ -13,14 +13,16 @@ rule:
     examples:
       - 1d8fd13c890060464019c0f07b928b1a:0x402eb0
   features:
-    - and:
-      - match: create or open mutex on Windows
-      - or:
-        - api: WaitForSingleObject
-        - basic block:
-          - and:
-            - api: GetLastError
-            - or:
-              - number: 2 = ERROR_FILE_NOT_FOUND
-              - number: 0xB7 = ERROR_ALREADY_EXISTS
-              - number: 5 = ERROR_ACCESS_DENIED
+    - or:
+      - api: ntdll.NtQueryMutant
+      - and:
+        - match: create or open mutex on Windows
+        - or:
+          - api: WaitForSingleObject
+          - basic block:
+            - and:
+              - api: GetLastError
+              - or:
+                - number: 2 = ERROR_FILE_NOT_FOUND
+                - number: 0xB7 = ERROR_ALREADY_EXISTS
+                - number: 5 = ERROR_ACCESS_DENIED

--- a/host-interaction/mutex/create-or-open-mutex-on-windows.yml
+++ b/host-interaction/mutex/create-or-open-mutex-on-windows.yml
@@ -18,6 +18,8 @@ rule:
       - api: kernel32.OpenMutex
       - api: kernel32.CreateMutex
       - api: kernel32.CreateMutexEx
+      - api: ntdll.NtCreateMutant
+      - api: ntdll.NtOpenMutant
       - and:
         - format: dotnet
         - or:


### PR DESCRIPTION
Adding APIs observed in CAPE reports. I'm not sure how CAPE logs dynamically resolved APIs, e.g., in this sample I'm observing that CAPE logs undocumented _Nt*_ counterparts for dynamically resolved APIs, e.g. _NtCreateMutant_ is logged for _CreateMutexA_...