### PR TITLE
Add rule: linux-rootkit-netfilter-hooks

### DIFF
--- a/nursery/linux-rootkit-netfilter-hooks.yml
+++ b/nursery/linux-rootkit-netfilter-hooks.yml
@@ -1,0 +1,15 @@
+rule:
+  meta:
+    name: linux-rootkit-netfilter-hooks
+    namespace:
+    authors:
+      - mrhafizfarhad@gmail.com
+    scopes:
+      static: file
+      dynamic: file
+    references:
+      - https://gist.github.com/loneicewolf/226e3e20e6041d12a63a5e833ebb0503
+  features:
+    - or:
+      - substring: nf_register_net_hook
+      - substring: nf_register_net_hooks


### PR DESCRIPTION
Addresses #998 
Hi @mike-hunhoff 

I am working on linux rootkit detection rules.

I started with Netfilter hooks detection since it doesn’t require offsets. I’m also trying to learn more about rootkits, so I thought this would be a straightforward approach.

However, I have a few questions:

1. I initially tried using API-based feature detection instead of string/substring matching, but the rule didn’t trigger (tested against this [rootkit code](https://gist.github.com/loneicewolf/226e3e20e6041d12a63a5e833ebb0503) that uses Netfilter hooks). I switched to substring detection as a workaround. Can we proceed with this approach, or might it introduce false positives?
2. Also, Is it acceptable to temporarily add these rules to the `nursery` directory until we develop 7–8 robust rules? If not, should they go under `anti-analysis/linux/rootkits/`, or do you recommend another location?