### PR TITLE
Unload minifilter drivers

### DIFF
--- a/host-interaction/driver/unload-driver.yml
+++ b/host-interaction/driver/unload-driver.yml
@@ -17,4 +17,3 @@ rule:
     - or:
       - api: NtUnloadDriver
       - api: ZwUnloadDriver
-      - api: fltlib.FilterUnload

--- a/host-interaction/driver/unload-driver.yml
+++ b/host-interaction/driver/unload-driver.yml
@@ -4,7 +4,6 @@ rule:
     namespace: host-interaction/driver
     authors:
       - moritz.raabe@mandiant.com
-      - JakePeralta7
     scopes:
       static: basic block
       dynamic: call

--- a/host-interaction/driver/unload-driver.yml
+++ b/host-interaction/driver/unload-driver.yml
@@ -11,7 +11,6 @@ rule:
       - Persistence::Create or Modify System Process::Windows Service [T1543.003]
     examples:
       - 31cee4f66cf3b537e3d2d37a71f339f4:0x1400044ce
-      - c3ef997d330e65be1e22ba4d2622ece23391c6cfc78b2ee515f3d0c7a3083a79:0x14000161D
   features:
     - or:
       - api: NtUnloadDriver

--- a/host-interaction/driver/unload-driver.yml
+++ b/host-interaction/driver/unload-driver.yml
@@ -4,6 +4,7 @@ rule:
     namespace: host-interaction/driver
     authors:
       - moritz.raabe@mandiant.com
+      - JakePeralta7
     scopes:
       static: basic block
       dynamic: call
@@ -11,7 +12,9 @@ rule:
       - Persistence::Create or Modify System Process::Windows Service [T1543.003]
     examples:
       - 31cee4f66cf3b537e3d2d37a71f339f4:0x1400044ce
+      - c3ef997d330e65be1e22ba4d2622ece23391c6cfc78b2ee515f3d0c7a3083a79:0x14000161D
   features:
     - or:
       - api: NtUnloadDriver
       - api: ZwUnloadDriver
+      - api: fltlib.FilterUnload

--- a/host-interaction/filter/unload-minifilter-driver.yml
+++ b/host-interaction/filter/unload-minifilter-driver.yml
@@ -1,0 +1,13 @@
+rule:
+  meta:
+    name: unload minifilter driver
+    namespace: host-interaction/filter
+    authors:
+      - JakePeralta7
+    scopes:
+      static: basic block
+      dynamic: call
+    examples:
+      - c3ef997d330e65be1e22ba4d2622ece23391c6cfc78b2ee515f3d0c7a3083a79:0x14000161D
+  features:
+    - api: fltlib.FilterUnload


### PR DESCRIPTION
Sysmon driver can be unloaded using `FilterUnload` from `fltlib.dll`.

Proof of concept:
https://github.com/getel-arch/Unload-Sysmon/blob/main/src/main.c