### PR TITLE
terminate process with RestartMgr.RmShutdown

### DIFF
--- a/host-interaction/process/terminate/terminate-process.yml
+++ b/host-interaction/process/terminate/terminate-process.yml
@@ -23,6 +23,7 @@ rule:
       - api: System.Windows.Forms.Application::Exit
       - api: exit
       - api: Exit
+      - and: RstrtMgr.RmShutdown
       - and:
         - os: linux
         - api: exit_group


### PR DESCRIPTION
Private sample with the following code will force termination of a process. Used in a sample to terminate processes that had a file locked.

https://learn.microsoft.com/en-us/windows/win32/api/restartmanager/nf-restartmanager-rmshutdown

```
v11 = RmShutdown(pSessionHandle, RmForceShutdown, 0LL);
```

